### PR TITLE
BI-3864 Exclude dependencies that were causing an SLF4J warning message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,16 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            
+            <!-- Without this exclusion, SLF4J warns about multiple bindings at start-up and we want
+                 to ensure that only the one directly embedded in the 'structured-logging' library is
+                 present and used -->
+            <exclusions>
+                <exclusion> 
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -58,6 +68,16 @@
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>structured-logging</artifactId>
             <version>${structured-logging.version}</version>
+
+            <!-- Without this exclusion, SLF4J warns about multiple bindings at start-up and we want
+                 to ensure that only the one directly embedded in the 'structured-logging' JAR is
+                 present and used -->
+            <exclusions>
+                <exclusion> 
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
@@ -105,6 +125,7 @@
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+
 
     </dependencies>
 


### PR DESCRIPTION
Addresses this warning message at start-up:

SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/Users/mwestacott/dev/SingleService/strike-off-objections-api/target/strike-off-objections-api-unversioned.jar!/BOOT-INF/lib/structured-logging-1.9.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/Users/mwestacott/dev/SingleService/strike-off-objections-api/target/strike-off-objections-api-unversioned.jar!/BOOT-INF/lib/logback-classic-1.2.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [ch.qos.logback.classic.util.ContextSelectorStaticBinder]