### PR TITLE
obj-63-add-attachment-to-api

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/common/ApiLogger.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/common/ApiLogger.java
@@ -31,10 +31,6 @@ public class ApiLogger {
         LOGGER.errorContext(context, e, null);
     }
 
-    public void errorContext(String context) {
-        LOGGER.errorContext(context, null, null);
-    }
-
     public void errorContext(String context, String message, Exception e) {
         LOGGER.errorContext(context, message, e, null);
     }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/common/ApiLogger.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/common/ApiLogger.java
@@ -31,6 +31,10 @@ public class ApiLogger {
         LOGGER.errorContext(context, e, null);
     }
 
+    public void errorContext(String context) {
+        LOGGER.errorContext(context, null, null);
+    }
+
     public void errorContext(String context, String message, Exception e) {
         LOGGER.errorContext(context, message, e, null);
     }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/config/ApplicationConfig.java
@@ -1,7 +1,9 @@
 package uk.gov.companieshouse.api.strikeoffobjections.config;
 
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDateTime;
 import java.util.function.Supplier;
@@ -12,6 +14,11 @@ public class ApplicationConfig {
     @Bean
     public Supplier<LocalDateTime> dateTimeNow() {
         return LocalDateTime::now;
+    }
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
@@ -121,7 +121,7 @@ public class ObjectionController {
 
             apiLogger.errorContext(
                     requestId,
-                    "Objection not found",
+                    OBJECTION_NOT_FOUND,
                     e,
                     logMap
             );
@@ -163,7 +163,7 @@ public class ObjectionController {
 
             apiLogger.errorContext(
                     requestId,
-                    "Objection not found",
+                    OBJECTION_NOT_FOUND,
                     e,
                     logMap
             );

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
@@ -195,7 +195,7 @@ public class ObjectionController {
         );
 
         try {
-            ServiceResult<String> result = objectionService.addAttachment(objectionId, file);
+            ServiceResult<String> result = objectionService.addAttachment(requestId, file);
             return new ResponseEntity(result.getData(), HttpStatus.OK);
         } catch(ServiceException e) {
 

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
@@ -131,14 +131,15 @@ public class ObjectionController {
     public ResponseEntity<String> uploadAttachmentToObjection (
             @RequestParam("file") MultipartFile file,
             @PathVariable("companyNumber") String companyNumber,
-            @PathVariable String objectionId) {
+            @PathVariable String objectionId,
+            @RequestHeader(value = ERIC_REQUEST_ID_HEADER) String requestId) {
 
         Map<String, Object> logMap = new HashMap<>();
         logMap.put(LOG_COMPANY_NUMBER_KEY, companyNumber);
         logMap.put(LOG_OBJECTION_ID_KEY, objectionId);
 
         apiLogger.infoContext(
-                objectionId,
+                requestId,
                 "POST /{objectionId}/attachments request received",
                 logMap
         );
@@ -149,7 +150,7 @@ public class ObjectionController {
         } catch(ServiceException e) {
 
             apiLogger.errorContext(
-                    objectionId,
+                    requestId,
                     "Objection not found",
                     e,
                     logMap
@@ -157,7 +158,7 @@ public class ObjectionController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         } finally {
             apiLogger.infoContext(
-                    objectionId,
+                     requestId,
                     "Finished POST /{objectionId}/attachments request",
                     logMap
             );

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
@@ -18,8 +18,6 @@ import org.springframework.web.multipart.MultipartFile;
 import uk.gov.companieshouse.api.strikeoffobjections.common.ApiLogger;
 import uk.gov.companieshouse.api.strikeoffobjections.common.LogConstants;
 import uk.gov.companieshouse.api.strikeoffobjections.exception.ObjectionNotFoundException;
-import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClient;
-import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClientResponse;
 import uk.gov.companieshouse.api.strikeoffobjections.model.patch.ObjectionPatch;
 import uk.gov.companieshouse.api.strikeoffobjections.model.response.ObjectionResponse;
 import uk.gov.companieshouse.api.strikeoffobjections.service.IObjectionService;

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
@@ -9,14 +9,19 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import org.springframework.web.multipart.MultipartFile;
 import uk.gov.companieshouse.api.strikeoffobjections.common.ApiLogger;
 import uk.gov.companieshouse.api.strikeoffobjections.common.LogConstants;
 import uk.gov.companieshouse.api.strikeoffobjections.exception.ObjectionNotFoundException;
+import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClient;
+import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClientResponse;
 import uk.gov.companieshouse.api.strikeoffobjections.model.patch.ObjectionPatch;
 import uk.gov.companieshouse.api.strikeoffobjections.model.response.ObjectionResponse;
 import uk.gov.companieshouse.api.strikeoffobjections.service.IObjectionService;
+import uk.gov.companieshouse.service.ServiceException;
 import uk.gov.companieshouse.service.ServiceResult;
 import uk.gov.companieshouse.service.rest.response.ChResponseBody;
 import uk.gov.companieshouse.service.rest.response.PluggableResponseEntityFactory;
@@ -34,10 +39,13 @@ public class ObjectionController {
 
     private PluggableResponseEntityFactory responseEntityFactory;
     private IObjectionService objectionService;
+
     private ApiLogger apiLogger;
 
     @Autowired
-    public ObjectionController(PluggableResponseEntityFactory responseEntityFactory, IObjectionService objectionService, ApiLogger apiLogger) {
+    public ObjectionController(PluggableResponseEntityFactory responseEntityFactory,
+                               IObjectionService objectionService,
+                               ApiLogger apiLogger) {
         this.responseEntityFactory = responseEntityFactory;
         this.objectionService = objectionService;
         this.apiLogger = apiLogger;
@@ -116,6 +124,18 @@ public class ObjectionController {
                     "Finished PATCH /{objectionId} request",
                     logMap
             );
+        }
+    }
+
+    @PostMapping("/{objectionId}/attachments")
+    public ResponseEntity<String> uploadAttachmentToRequest(
+            @RequestParam("file") MultipartFile file, @PathVariable String objectionId) {
+        try {
+            ServiceResult<String> result = objectionService.addAttachment(objectionId, file);
+            return new ResponseEntity(result, HttpStatus.OK);
+        } catch(ServiceException e) {
+
+            return ResponseEntity.status(503).build();
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
@@ -128,14 +128,39 @@ public class ObjectionController {
     }
 
     @PostMapping("/{objectionId}/attachments")
-    public ResponseEntity<String> uploadAttachmentToRequest(
-            @RequestParam("file") MultipartFile file, @PathVariable String objectionId) {
+    public ResponseEntity<String> uploadAttachmentToObjection (
+            @RequestParam("file") MultipartFile file,
+            @PathVariable("companyNumber") String companyNumber,
+            @PathVariable String objectionId) {
+
+        Map<String, Object> logMap = new HashMap<>();
+        logMap.put(LOG_COMPANY_NUMBER_KEY, companyNumber);
+        logMap.put(LOG_OBJECTION_ID_KEY, objectionId);
+
+        apiLogger.infoContext(
+                objectionId,
+                "POST /{objectionId}/attachments request received",
+                logMap
+        );
+
         try {
             ServiceResult<String> result = objectionService.addAttachment(objectionId, file);
-            return new ResponseEntity(result, HttpStatus.OK);
+            return new ResponseEntity(result.getData(), HttpStatus.OK);
         } catch(ServiceException e) {
 
-            return ResponseEntity.status(503).build();
+            apiLogger.errorContext(
+                    objectionId,
+                    "Objection not found",
+                    e,
+                    logMap
+            );
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        } finally {
+            apiLogger.infoContext(
+                    objectionId,
+                    "Finished POST /{objectionId}/attachments request",
+                    logMap
+            );
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
@@ -41,6 +41,7 @@ public class ObjectionController {
     private static final String LOG_COMPANY_NUMBER_KEY = LogConstants.COMPANY_NUMBER.getValue();
     private static final String LOG_OBJECTION_ID_KEY = LogConstants.OBJECTION_ID.getValue();
     private static final String ERIC_REQUEST_ID_HEADER = "X-Request-Id";
+    public static final String OBJECTION_NOT_FOUND = "Objection not found";
 
     private PluggableResponseEntityFactory responseEntityFactory;
     private IObjectionService objectionService;
@@ -201,7 +202,7 @@ public class ObjectionController {
 
             apiLogger.errorContext(
                     requestId,
-                    "Objection not found",
+                    OBJECTION_NOT_FOUND,
                     e,
                     logMap
             );

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.companieshouse.api.strikeoffobjections.common.ApiLogger;
 import uk.gov.companieshouse.api.strikeoffobjections.common.LogConstants;
@@ -156,6 +158,16 @@ public class ObjectionController {
                     logMap
             );
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        } catch(HttpClientErrorException | HttpServerErrorException e) {
+
+            apiLogger.errorContext(
+                    requestId,
+                    String.format("The file-transfer-api has returned an error for file: %s",
+                            file.getOriginalFilename()),
+                    e,
+                    logMap
+            );
+            return ResponseEntity.status(e.getStatusCode()).build();
         } finally {
             apiLogger.infoContext(
                      requestId,

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiClient.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiClient.java
@@ -73,7 +73,7 @@ public class FileTransferApiClient {
      * call ready to pass to the response builder
      * @param fileToUpload
      * @return ResponseEntity containing the raw data from which the response object is built
-     * @throws IOException
+     * @throws IOException when multipart file bytes have access errors
      */
     private ResponseEntity<FileTransferApiResponse> getFileTransferOperation(MultipartFile fileToUpload) throws IOException {
         HttpHeaders headers = createFileTransferApiHttpHeaders();
@@ -88,7 +88,7 @@ public class FileTransferApiClient {
      * FileTransferResponseBuilder - the output from FileTransferOperation is the input into
      * this FileTransferResponseBuilder
      * @param responseEntity
-     * @return
+     * @return FileTransferApiClientResponse contains data ready to add to mongo
      */
     private FileTransferApiClientResponse getFileTransferApiClientResponse(
             String requestId, ResponseEntity<FileTransferApiResponse> responseEntity) {

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiClient.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiClient.java
@@ -21,8 +21,6 @@ public class FileTransferApiClient {
     private static final String CONTENT_DISPOSITION_VALUE = "form-data; name=%s; filename=%s";
     private static final String NULL_RESPONSE_MESSAGE = "null response from file transfer api url";
 
-    private String requestId;
-
     @Autowired
     private ApiLogger logger;
 
@@ -36,7 +34,8 @@ public class FileTransferApiClient {
     private String fileTransferApiKey;
 
 
-    private <T> FileTransferApiClientResponse makeApiCall(FileTransferOperation <T> operation,
+    private <T> FileTransferApiClientResponse makeApiCall(String requestId,
+                                                          FileTransferOperation <T> operation,
                                                           FileTransferResponseBuilder <T> responseBuilder) {
         FileTransferApiClientResponse response = new FileTransferApiClientResponse();
 
@@ -59,10 +58,11 @@ public class FileTransferApiClient {
      * @return FileTransferApiClientResponse containing the file id if successful, the http header and http status
      */
     public FileTransferApiClientResponse upload(String requestId, MultipartFile fileToUpload) {
-        this.requestId = requestId;
+
         return makeApiCall(
+             requestId,
              () -> getFileTransferOperation(fileToUpload),
-             responseEntity ->  getFileTransferApiClientResponse(responseEntity)
+             responseEntity ->  getFileTransferApiClientResponse(requestId, responseEntity)
         );
     }
 
@@ -88,7 +88,8 @@ public class FileTransferApiClient {
      * @param responseEntity
      * @return
      */
-    private FileTransferApiClientResponse getFileTransferApiClientResponse(ResponseEntity<FileTransferApiResponse> responseEntity) {
+    private FileTransferApiClientResponse getFileTransferApiClientResponse(
+            String requestId, ResponseEntity<FileTransferApiResponse> responseEntity) {
         FileTransferApiClientResponse fileTransferApiClientResponse = new FileTransferApiClientResponse();
         if (responseEntity != null) {
             fileTransferApiClientResponse.setHttpHeaders(responseEntity.getHeaders());

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiClient.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiClient.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
@@ -14,6 +15,7 @@ import uk.gov.companieshouse.api.strikeoffobjections.common.ApiLogger;
 
 import java.io.IOException;
 
+@Component
 public class FileTransferApiClient {
 
     private static final String HEADER_API_KEY = "x-api-key";

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiClient.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiClient.java
@@ -1,0 +1,125 @@
+package uk.gov.companieshouse.api.strikeoffobjections.file;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+import uk.gov.companieshouse.api.strikeoffobjections.common.ApiLogger;
+
+import java.io.IOException;
+
+public class FileTransferApiClient {
+
+    private static final String HEADER_API_KEY = "x-api-key";
+    private static final String UPLOAD = "upload";
+    private static final String CONTENT_DISPOSITION_VALUE = "form-data; name=%s; filename=%s";
+    private static final String NULL_RESPONSE_MESSAGE = "null response from file transfer api url";
+
+    @Autowired
+    private ApiLogger logger;
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Value("${FILE_TRANSFER_API_URL}")
+    private String fileTransferApiURL;
+
+    @Value("${FILE_TRANSFER_API_KEY}")
+    private String fileTransferApiKey;
+
+
+    private <T> FileTransferApiClientResponse makeApiCall(FileTransferOperation <T> operation,
+                                                          FileTransferResponseBuilder <T> responseBuilder) {
+        FileTransferApiClientResponse response = new FileTransferApiClientResponse();
+
+        try {
+            T operationResponse = operation.execute();
+            response = responseBuilder.createResponse(operationResponse);
+        } catch (IOException e) {
+            logger.errorContext(e.getMessage(), e);
+            response.setHttpStatus(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        return response;
+    }
+
+    /**
+     * Uploads a file to the file-transfer-api
+     * Creates a multipart form request containing the file and sends to
+     * the file-transfer-api. The response from the file-transfer-api contains
+     * the new unique id for the file. This is captured and returned in the FileTransferApiClientResponse.
+     * @param fileToUpload The file to upload
+     * @return FileTransferApiClientResponse containing the file id if successful, and http status
+     */
+    public FileTransferApiClientResponse upload(MultipartFile fileToUpload) {
+        return makeApiCall(
+             () -> getFileTransferOperation(fileToUpload),
+             responseEntity ->  getFileTransferApiClientResponse(responseEntity)
+        );
+    }
+
+    /**
+     * @param fileToUpload
+     * @return
+     * @throws IOException
+     */
+    private ResponseEntity<FileTransferApiResponse> getFileTransferOperation(MultipartFile fileToUpload) throws IOException {
+        HttpHeaders headers = createFileTransferApiHttpHeaders();
+        LinkedMultiValueMap<String, String> fileHeaderMap = createUploadFileHeader(fileToUpload);
+        HttpEntity<byte[]> fileHttpEntity = new HttpEntity<>(fileToUpload.getBytes(), fileHeaderMap);
+        LinkedMultiValueMap<String, Object> body = createUploadBody(fileHttpEntity);
+        HttpEntity<LinkedMultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+        return restTemplate.postForEntity(fileTransferApiURL, requestEntity, FileTransferApiResponse.class);
+    }
+
+    /**
+     * FileTransferResponseBuilder - the output from FileTransferOperation is the input into
+     * this FileTransferResponseBuilder
+     * @param responseEntity
+     * @return
+     */
+    private FileTransferApiClientResponse getFileTransferApiClientResponse(ResponseEntity<FileTransferApiResponse> responseEntity) {
+        FileTransferApiClientResponse fileTransferApiClientResponse = new FileTransferApiClientResponse();
+        if (responseEntity != null) {
+            fileTransferApiClientResponse.setHeaders(responseEntity.getHeaders());
+            fileTransferApiClientResponse.setHttpStatus(responseEntity.getStatusCode());
+            FileTransferApiResponse apiResponse = responseEntity.getBody();
+            if (apiResponse != null) {
+                fileTransferApiClientResponse.setFileId(apiResponse.getId());
+            }
+        } else {
+            logger.errorContext(String.format("%s %s", NULL_RESPONSE_MESSAGE,fileTransferApiURL));
+            fileTransferApiClientResponse.setHttpStatus(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        return fileTransferApiClientResponse;
+    }
+
+    private HttpHeaders createFileTransferApiHttpHeaders() {
+        HttpHeaders headers = createApiKeyHeader();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+        return headers;
+    }
+
+    private HttpHeaders createApiKeyHeader() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HEADER_API_KEY, fileTransferApiKey);
+        return headers;
+    }
+
+    private LinkedMultiValueMap<String, String> createUploadFileHeader(MultipartFile fileToUpload) {
+        LinkedMultiValueMap<String, String> fileHeaderMap = new LinkedMultiValueMap<>();
+        fileHeaderMap.add(HttpHeaders.CONTENT_DISPOSITION, String.format(CONTENT_DISPOSITION_VALUE, UPLOAD, fileToUpload.getOriginalFilename()));
+        return fileHeaderMap;
+    }
+
+    private LinkedMultiValueMap<String, Object> createUploadBody(HttpEntity<byte[]> fileHttpEntity) {
+        LinkedMultiValueMap<String, Object> multipartReqMap = new LinkedMultiValueMap<>();
+        multipartReqMap.add(UPLOAD, fileHttpEntity);
+        return multipartReqMap;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiClient.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiClient.java
@@ -71,7 +71,7 @@ public class FileTransferApiClient {
     /**
      * Calls the file transfer api and returns the result of the
      * call ready to pass to the response builder
-     * @param fileToUpload
+     * @param fileToUpload multipart file to be uploaded
      * @return ResponseEntity containing the raw data from which the response object is built
      * @throws IOException when multipart file bytes have access errors
      */
@@ -87,7 +87,7 @@ public class FileTransferApiClient {
     /**
      * FileTransferResponseBuilder - the output from FileTransferOperation is the input into
      * this FileTransferResponseBuilder
-     * @param responseEntity
+     * @param responseEntity raw data returned from file transfer api upload call
      * @return FileTransferApiClientResponse contains data ready to add to mongo
      */
     private FileTransferApiClientResponse getFileTransferApiClientResponse(

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiClientResponse.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiClientResponse.java
@@ -1,0 +1,35 @@
+package uk.gov.companieshouse.api.strikeoffobjections.file;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+
+public class FileTransferApiClientResponse {
+
+    private String fileId;
+    private HttpStatus httpStatus;
+    private HttpHeaders headers;
+
+    public String getFileId() {
+        return fileId;
+    }
+
+    public void setFileId(String fileId) {
+        this.fileId = fileId;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public void setHttpStatus(HttpStatus httpStatus) {
+        this.httpStatus = httpStatus;
+    }
+
+    public HttpHeaders getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(HttpHeaders headers) {
+        this.headers = headers;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiClientResponse.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiClientResponse.java
@@ -7,7 +7,7 @@ public class FileTransferApiClientResponse {
 
     private String fileId;
     private HttpStatus httpStatus;
-    private HttpHeaders headers;
+    private HttpHeaders httpHeaders;
 
     public String getFileId() {
         return fileId;
@@ -25,11 +25,11 @@ public class FileTransferApiClientResponse {
         this.httpStatus = httpStatus;
     }
 
-    public HttpHeaders getHeaders() {
-        return headers;
+    public HttpHeaders getHttpHeaders() {
+        return httpHeaders;
     }
 
-    public void setHeaders(HttpHeaders headers) {
-        this.headers = headers;
+    public void setHttpHeaders(HttpHeaders httpHeaders) {
+        this.httpHeaders = httpHeaders;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiResponse.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiResponse.java
@@ -1,0 +1,14 @@
+package uk.gov.companieshouse.api.strikeoffobjections.file;
+
+public class FileTransferApiResponse {
+
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferOperation.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferOperation.java
@@ -1,0 +1,8 @@
+package uk.gov.companieshouse.api.strikeoffobjections.file;
+
+import java.io.IOException;
+
+@FunctionalInterface
+public interface FileTransferOperation<T>  {
+    T execute() throws IOException;
+}

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferResponseBuilder.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferResponseBuilder.java
@@ -1,0 +1,8 @@
+package uk.gov.companieshouse.api.strikeoffobjections.file;
+
+import java.io.IOException;
+
+@FunctionalInterface
+public interface FileTransferResponseBuilder<T> {
+    FileTransferApiClientResponse createResponse(T input) throws IOException;
+}

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
@@ -18,5 +18,5 @@ public interface IObjectionService {
     List<Attachment> getAttachments(String requestId, String companyNumber,String objectionId)
             throws ObjectionNotFoundException;
 
-    ServiceResult<String> addAttachment(String objectionId, MultipartFile file) throws ServiceException;
+    ServiceResult<String> addAttachment(String requestId, MultipartFile file) throws ServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
@@ -1,9 +1,13 @@
 package uk.gov.companieshouse.api.strikeoffobjections.service;
 
+import org.springframework.web.multipart.MultipartFile;
 import uk.gov.companieshouse.api.strikeoffobjections.exception.ObjectionNotFoundException;
 import uk.gov.companieshouse.api.strikeoffobjections.model.patch.ObjectionPatch;
+import uk.gov.companieshouse.service.ServiceException;
+import uk.gov.companieshouse.service.ServiceResult;
 
 public interface IObjectionService {
     String createObjection(String requestId, String companyNumber) throws Exception;
     void patchObjection(String requestId, String companyNumber,String objectionID, ObjectionPatch objectionPatch) throws ObjectionNotFoundException;
+    ServiceResult<String> addAttachment(String requestId, MultipartFile file) throws ServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
@@ -1,15 +1,22 @@
 package uk.gov.companieshouse.api.strikeoffobjections.service.impl;
 
+import org.junit.platform.commons.util.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 import uk.gov.companieshouse.api.strikeoffobjections.common.ApiLogger;
 import uk.gov.companieshouse.api.strikeoffobjections.common.LogConstants;
 import uk.gov.companieshouse.api.strikeoffobjections.exception.ObjectionNotFoundException;
+import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClient;
+import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClientResponse;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
 import uk.gov.companieshouse.api.strikeoffobjections.model.patcher.ObjectionPatcher;
 import uk.gov.companieshouse.api.strikeoffobjections.model.patch.ObjectionPatch;
 import uk.gov.companieshouse.api.strikeoffobjections.repository.ObjectionRepository;
 import uk.gov.companieshouse.api.strikeoffobjections.service.IObjectionService;
+import uk.gov.companieshouse.service.ServiceException;
+import uk.gov.companieshouse.service.ServiceResult;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
@@ -24,13 +31,19 @@ public class ObjectionService implements IObjectionService {
     private ApiLogger logger;
     private Supplier<LocalDateTime> dateTimeSupplier;
     private ObjectionPatcher objectionPatcher;
+    private FileTransferApiClient fileTransferApiClient;
 
     @Autowired
-    public ObjectionService(ObjectionRepository objectionRepository, ApiLogger logger, Supplier<LocalDateTime> dateTimeSupplier, ObjectionPatcher objectionPatcher) {
+    public ObjectionService(ObjectionRepository objectionRepository,
+                            ApiLogger logger,
+                            Supplier<LocalDateTime> dateTimeSupplier,
+                            ObjectionPatcher objectionPatcher,
+                            FileTransferApiClient fileTransferApiClient) {
         this.objectionRepository = objectionRepository;
         this.logger = logger;
         this.dateTimeSupplier = dateTimeSupplier;
         this.objectionPatcher = objectionPatcher;
+        this.fileTransferApiClient = fileTransferApiClient;
     }
 
     @Override
@@ -64,6 +77,22 @@ public class ObjectionService implements IObjectionService {
         } else {
             logger.infoContext(requestId, "Objection does not exist", logMap);
             throw new ObjectionNotFoundException(String.format("Objection ID: %s, not found", objectionID));
+        }
+    }
+
+    @Override
+    public ServiceResult<String> addAttachment(String objectionId, MultipartFile file) throws ServiceException {
+        FileTransferApiClientResponse response = fileTransferApiClient.upload(objectionId, file);
+
+        HttpStatus responseHttpStatus = response.getHttpStatus();
+        if (responseHttpStatus != null && responseHttpStatus.isError()) {
+            throw new ServiceException(responseHttpStatus.toString());
+        }
+        String fileId = response.getFileId();
+        if (StringUtils.isBlank(fileId)) {
+            throw new ServiceException("No file id returned from file upload");
+        } else {
+            return ServiceResult.accepted(fileId);
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
@@ -85,8 +85,8 @@ public class ObjectionService implements IObjectionService {
     }
 
     @Override
-    public ServiceResult<String> addAttachment(String objectionId, MultipartFile file) throws ServiceException {
-        FileTransferApiClientResponse response = fileTransferApiClient.upload(objectionId, file);
+    public ServiceResult<String> addAttachment(String requestId, MultipartFile file) throws ServiceException {
+        FileTransferApiClientResponse response = fileTransferApiClient.upload(requestId, file);
 
         HttpStatus responseHttpStatus = response.getHttpStatus();
         if (responseHttpStatus != null && responseHttpStatus.isError()) {

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiClientUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiClientUnitTest.java
@@ -1,0 +1,106 @@
+package uk.gov.companieshouse.api.strikeoffobjections.file;
+
+import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.commons.util.StringUtils;
+import org.junit.rules.ExpectedException;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+import uk.gov.companieshouse.api.strikeoffobjections.common.ApiLogger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class FileTransferApiClientUnitTest {
+
+    private static final String DUMMY_URL = "http://test";
+    private static final String FILE_ID = "12345";
+    private static final String EXCEPTION_MESSAGE = "BAD THINGS";
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Mock
+    private ApiLogger apiLogger;
+
+    @InjectMocks
+    private FileTransferApiClient fileTransferApiClient;
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    private MultipartFile file;
+
+    @BeforeEach
+    public void setup() {
+        ReflectionTestUtils.setField(fileTransferApiClient, "fileTransferApiURL", DUMMY_URL);
+        file = new MockMultipartFile("testFile", new byte[10]);
+    }
+
+    @Test
+    public void testUpload_success() {
+        final ResponseEntity<FileTransferApiResponse> apiResponse = apiSuccessResponse();
+
+        when(restTemplate.postForEntity(eq(DUMMY_URL), any(), eq(FileTransferApiResponse.class)))
+                .thenReturn(apiResponse);
+
+        FileTransferApiClientResponse fileTransferApiClientResponse = fileTransferApiClient.upload(file);
+
+        assertEquals(FILE_ID, fileTransferApiClientResponse.getFileId());
+        assertEquals(HttpStatus.OK, fileTransferApiClientResponse.getHttpStatus());
+    }
+
+    @Test
+    public void testUpload_ApiReturnsError() {
+        final ResponseEntity<FileTransferApiResponse> apiErrorResponse = apiErrorResponse();
+
+        when(restTemplate.postForEntity(eq(DUMMY_URL), any(), eq(FileTransferApiResponse.class))).thenReturn(apiErrorResponse);
+
+        FileTransferApiClientResponse fileTransferApiClientResponse = fileTransferApiClient.upload(file);
+
+        assertTrue(fileTransferApiClientResponse.getHttpStatus().isError());
+        assertEquals(apiErrorResponse.getStatusCode(), fileTransferApiClientResponse.getHttpStatus());
+        assertTrue(StringUtils.isBlank(fileTransferApiClientResponse.getFileId()));
+    }
+
+    @Test
+    public void testUpload_GenericExceptionResponse() {
+        final RestClientException exception = new RestClientException(EXCEPTION_MESSAGE);
+
+        when(restTemplate.postForEntity(eq(DUMMY_URL), any(), eq(FileTransferApiResponse.class))).thenThrow(exception);
+
+        expectedException.expect(RestClientException.class);
+        expectedException.expectMessage(exception.getMessage());
+
+        assertThrows(RestClientException.class, () -> fileTransferApiClient.upload(file));
+    }
+
+
+
+    private ResponseEntity<FileTransferApiResponse> apiSuccessResponse() {
+        FileTransferApiResponse response = new FileTransferApiResponse();
+        response.setId(FILE_ID);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    private ResponseEntity<FileTransferApiResponse> apiErrorResponse() {
+        FileTransferApiResponse response = new FileTransferApiResponse();
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiClientUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiClientUnitTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class FileTransferApiClientUnitTest {
 
+    private static final String REQUEST_ID = "abc";
     private static final String DUMMY_URL = "http://test";
     private static final String FILE_ID = "12345";
     private static final String EXCEPTION_MESSAGE = "BAD THINGS";
@@ -59,7 +60,7 @@ public class FileTransferApiClientUnitTest {
         when(restTemplate.postForEntity(eq(DUMMY_URL), any(), eq(FileTransferApiResponse.class)))
                 .thenReturn(apiResponse);
 
-        FileTransferApiClientResponse fileTransferApiClientResponse = fileTransferApiClient.upload(file);
+        FileTransferApiClientResponse fileTransferApiClientResponse = fileTransferApiClient.upload(REQUEST_ID, file);
 
         assertEquals(FILE_ID, fileTransferApiClientResponse.getFileId());
         assertEquals(HttpStatus.OK, fileTransferApiClientResponse.getHttpStatus());
@@ -71,7 +72,7 @@ public class FileTransferApiClientUnitTest {
 
         when(restTemplate.postForEntity(eq(DUMMY_URL), any(), eq(FileTransferApiResponse.class))).thenReturn(apiErrorResponse);
 
-        FileTransferApiClientResponse fileTransferApiClientResponse = fileTransferApiClient.upload(file);
+        FileTransferApiClientResponse fileTransferApiClientResponse = fileTransferApiClient.upload(REQUEST_ID, file);
 
         assertTrue(fileTransferApiClientResponse.getHttpStatus().isError());
         assertEquals(apiErrorResponse.getStatusCode(), fileTransferApiClientResponse.getHttpStatus());
@@ -87,10 +88,8 @@ public class FileTransferApiClientUnitTest {
         expectedException.expect(RestClientException.class);
         expectedException.expectMessage(exception.getMessage());
 
-        assertThrows(RestClientException.class, () -> fileTransferApiClient.upload(file));
+        assertThrows(RestClientException.class, () -> fileTransferApiClient.upload(REQUEST_ID, file));
     }
-
-
 
     private ResponseEntity<FileTransferApiResponse> apiSuccessResponse() {
         FileTransferApiResponse response = new FileTransferApiResponse();
@@ -102,5 +101,4 @@ public class FileTransferApiClientUnitTest {
         FileTransferApiResponse response = new FileTransferApiResponse();
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
-
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
@@ -102,7 +102,7 @@ class ObjectionServiceTest {
     }
 
     @Test
-    void patchObjectionDoesNotExistTest() throws Exception {
+    void patchObjectionDoesNotExistTest() {
         ObjectionPatch objectionPatch = new ObjectionPatch();
         objectionPatch.setReason(REASON);
         objectionPatch.setStatus(ObjectionStatus.OPEN);
@@ -128,7 +128,7 @@ class ObjectionServiceTest {
     }
 
     @Test
-    void getAttachmentsWhenObjectionDoesNotExistTest() throws Exception {
+    void getAttachmentsWhenObjectionDoesNotExistTest() {
         when(objectionRepository.findById(any())).thenReturn(Optional.empty());
 
         assertThrows(ObjectionNotFoundException.class, () -> objectionService.getAttachments(REQUEST_ID, COMPANY_NUMBER, OBJECTION_ID));
@@ -140,7 +140,7 @@ class ObjectionServiceTest {
     public void willThrowServiceExceptionIfUploadErrors() throws Exception {
         when(fileTransferApiClient.upload(anyString(), any(MultipartFile.class))).thenReturn(Utils.getUnsuccessfulUploadResponse());
         try {
-            objectionService.addAttachment(OBJECTION_ID, Utils.mockMultipartFile());
+            objectionService.addAttachment(REQUEST_ID, Utils.mockMultipartFile());
             fail();
         } catch(ServiceException e) {
             assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.toString(), e.getMessage());
@@ -152,7 +152,7 @@ class ObjectionServiceTest {
         when(fileTransferApiClient.upload(anyString(), any(MultipartFile.class)))
                 .thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
         try {
-            objectionService.addAttachment(OBJECTION_ID, Utils.mockMultipartFile());
+            objectionService.addAttachment(REQUEST_ID, Utils.mockMultipartFile());
             fail();
         } catch(HttpServerErrorException e) {
             assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.toString(), e.getMessage());
@@ -164,7 +164,7 @@ class ObjectionServiceTest {
         when(fileTransferApiClient.upload(anyString(), any(MultipartFile.class)))
                 .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
         try {
-            objectionService.addAttachment(OBJECTION_ID, Utils.mockMultipartFile());
+            objectionService.addAttachment(REQUEST_ID, Utils.mockMultipartFile());
             fail();
         } catch(HttpClientErrorException e) {
             assertEquals(HttpStatus.BAD_REQUEST.toString(), e.getMessage());
@@ -179,7 +179,7 @@ class ObjectionServiceTest {
                 .thenReturn(response);
 
         assertThrows(ServiceException.class, () ->
-                objectionService.addAttachment(OBJECTION_ID, Utils.mockMultipartFile()));
+                objectionService.addAttachment(REQUEST_ID, Utils.mockMultipartFile()));
 
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/utils/Utils.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/utils/Utils.java
@@ -1,0 +1,36 @@
+package uk.gov.companieshouse.api.strikeoffobjections.utils;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClientResponse;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+public class Utils {
+
+    public static final String ORIGINAL_FILE_NAME = "original.png";
+    private static final String UPLOAD_ID = "5agf-g6hh";
+
+    public static MultipartFile mockMultipartFile() throws IOException {
+        String fileName = "testMultipart.txt";
+        Resource rsc = new ClassPathResource("input/testMultipart.txt");
+        return new MockMultipartFile(fileName,
+                ORIGINAL_FILE_NAME, "text/plain", Files.readAllBytes(rsc.getFile().toPath()));
+    }
+
+    public static FileTransferApiClientResponse getSuccessfulUploadResponse() {
+        FileTransferApiClientResponse fileTransferApiClientResponse = new FileTransferApiClientResponse();
+        fileTransferApiClientResponse.setFileId(UPLOAD_ID);
+        return fileTransferApiClientResponse;
+    }
+
+    public static FileTransferApiClientResponse getUnsuccessfulUploadResponse() {
+        FileTransferApiClientResponse fileTransferApiClientResponse = new FileTransferApiClientResponse();
+        fileTransferApiClientResponse.setHttpStatus(HttpStatus.INTERNAL_SERVER_ERROR);
+        return fileTransferApiClientResponse;
+    }
+}

--- a/src/test/resources/input/testMultipart.txt
+++ b/src/test/resources/input/testMultipart.txt
@@ -1,0 +1,1 @@
+test text


### PR DESCRIPTION
Borrowed heavily from extensions-api - have refactored out the annonymous calls in the client into their own methods so it is more readable and clearer what the objects returned are. Moreover, updated unit tests to use junit jupiter. Also added headers to the response object in line with the acceptance criteria.

So far only been able to test with unit tests.