### PR TITLE
Feature/obj 63 add attachment to mongo

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
@@ -180,7 +180,7 @@ public class ObjectionController {
     }
 
     @PostMapping("/{objectionId}/attachments")
-    public ResponseEntity uploadAttachmentToObjection (
+    public ResponseEntity<String> uploadAttachmentToObjection (
             @RequestParam("file") MultipartFile file,
             @PathVariable("companyNumber") String companyNumber,
             @PathVariable String objectionId,
@@ -198,8 +198,8 @@ public class ObjectionController {
         );
 
         try {
-            objectionService.addAttachment(requestId, objectionId, file, servletRequest.getRequestURI());
-            return new ResponseEntity(HttpStatus.NO_CONTENT);
+            ServiceResult<String> result = objectionService.addAttachment(requestId, objectionId, file, servletRequest.getRequestURI());
+            return new ResponseEntity(result.getData(), HttpStatus.CREATED);
         } catch(ServiceException e) {
 
             apiLogger.errorContext(

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/ObjectionsLinkKeys.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/file/ObjectionsLinkKeys.java
@@ -1,0 +1,19 @@
+package uk.gov.companieshouse.api.strikeoffobjections.file;
+
+import uk.gov.companieshouse.service.links.CoreLinkKeys;
+import uk.gov.companieshouse.service.links.LinkKey;
+
+public enum ObjectionsLinkKeys implements LinkKey {
+    DOWNLOAD("download"),
+    SELF(CoreLinkKeys.SELF.key());
+
+    private final String key;
+
+    private ObjectionsLinkKeys(String key) {
+        this.key = key;
+    }
+
+    public String key() {
+        return this.key;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
@@ -7,7 +7,6 @@ import uk.gov.companieshouse.api.strikeoffobjections.exception.ObjectionNotFound
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
 import uk.gov.companieshouse.api.strikeoffobjections.model.patch.ObjectionPatch;
 import uk.gov.companieshouse.service.ServiceException;
-import uk.gov.companieshouse.service.ServiceResult;
 
 public interface IObjectionService {
     String createObjection(String requestId, String companyNumber) throws Exception;
@@ -18,5 +17,5 @@ public interface IObjectionService {
     List<Attachment> getAttachments(String requestId, String companyNumber,String objectionId)
             throws ObjectionNotFoundException;
 
-    ServiceResult<String> addAttachment(String requestId, MultipartFile file) throws ServiceException;
+    void addAttachment(String requestId, String objectionId, MultipartFile file, String attachmentsUri) throws ServiceException, ObjectionNotFoundException;
 }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
@@ -7,6 +7,7 @@ import uk.gov.companieshouse.api.strikeoffobjections.exception.ObjectionNotFound
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
 import uk.gov.companieshouse.api.strikeoffobjections.model.patch.ObjectionPatch;
 import uk.gov.companieshouse.service.ServiceException;
+import uk.gov.companieshouse.service.ServiceResult;
 
 public interface IObjectionService {
     String createObjection(String requestId, String companyNumber) throws Exception;
@@ -17,5 +18,5 @@ public interface IObjectionService {
     List<Attachment> getAttachments(String requestId, String companyNumber,String objectionId)
             throws ObjectionNotFoundException;
 
-    void addAttachment(String requestId, String objectionId, MultipartFile file, String attachmentsUri) throws ServiceException, ObjectionNotFoundException;
+    ServiceResult<String> addAttachment(String requestId, String objectionId, MultipartFile file, String attachmentsUri) throws ServiceException, ObjectionNotFoundException;
 }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
@@ -33,7 +33,7 @@ import java.util.function.Supplier;
 @Service
 public class ObjectionService implements IObjectionService {
 
-    private static String OBJECTION_NOT_FOUND_MESSAGE = "Objection with id: %s, not found";
+    private static final String OBJECTION_NOT_FOUND_MESSAGE = "Objection with id: %s, not found";
 
     private ObjectionRepository objectionRepository;
     private ApiLogger logger;

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
@@ -33,6 +33,8 @@ import java.util.function.Supplier;
 @Service
 public class ObjectionService implements IObjectionService {
 
+    private static String OBJECTION_NOT_FOUND_MESSAGE = "Objection with id: %s, not found";
+
     private ObjectionRepository objectionRepository;
     private ApiLogger logger;
     private Supplier<LocalDateTime> dateTimeSupplier;
@@ -83,7 +85,7 @@ public class ObjectionService implements IObjectionService {
             objectionRepository.save(objection);
         } else {
             logger.infoContext(requestId, "Objection does not exist", logMap);
-            throw new ObjectionNotFoundException(String.format("Objection with id: %s, not found", objectionId));
+            throw new ObjectionNotFoundException(String.format(OBJECTION_NOT_FOUND_MESSAGE, objectionId));
         }
     }
 
@@ -106,7 +108,7 @@ public class ObjectionService implements IObjectionService {
         } else {
             Attachment attachment = createAttachment(file, attachmentId);
             Objection objection = objectionRepository.findById(objectionId).orElseThrow(
-                    () -> new ObjectionNotFoundException(String.format("Objection with id: %s, not found", objectionId))
+                    () -> new ObjectionNotFoundException(String.format(OBJECTION_NOT_FOUND_MESSAGE, objectionId))
             );
             objection.addAttachment(attachment);
 
@@ -150,7 +152,7 @@ public class ObjectionService implements IObjectionService {
             return objection.get().getAttachments();
         } else {
             logger.infoContext(requestId, "Objection does not exist", logMap);
-            throw new ObjectionNotFoundException(String.format("Objection with id: %s, not found", objectionId));
+            throw new ObjectionNotFoundException(String.format(OBJECTION_NOT_FOUND_MESSAGE, objectionId));
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
@@ -19,6 +19,7 @@ import uk.gov.companieshouse.api.strikeoffobjections.model.patch.ObjectionPatch;
 import uk.gov.companieshouse.api.strikeoffobjections.repository.ObjectionRepository;
 import uk.gov.companieshouse.api.strikeoffobjections.service.IObjectionService;
 import uk.gov.companieshouse.service.ServiceException;
+import uk.gov.companieshouse.service.ServiceResult;
 import uk.gov.companieshouse.service.links.Links;
 
 import javax.validation.constraints.NotNull;
@@ -87,10 +88,14 @@ public class ObjectionService implements IObjectionService {
     }
 
     @Override
-    public void addAttachment(String requestId, String objectionId, MultipartFile file, String attachmentsUri)
+    public ServiceResult<String> addAttachment(String requestId, String objectionId, MultipartFile file, String attachmentsUri)
             throws ServiceException, ObjectionNotFoundException {
-
+        Map<String, Object> logMap = new HashMap<>();
+        logMap.put(LogConstants.OBJECTION_ID.getValue(), objectionId);
+        logger.infoContext(requestId, "Uploading attachments", logMap);
         FileTransferApiClientResponse response = fileTransferApiClient.upload(requestId, file);
+        logger.infoContext(requestId, "Finished uploading attachments", logMap);
+
         HttpStatus responseHttpStatus = response.getHttpStatus();
         if (responseHttpStatus != null && responseHttpStatus.isError()) {
             throw new ServiceException(responseHttpStatus.toString());
@@ -109,6 +114,8 @@ public class ObjectionService implements IObjectionService {
             attachment.setLinks(links);
 
             objectionRepository.save(objection);
+
+            return ServiceResult.accepted(attachmentId);
         }
     }
 

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
@@ -9,12 +9,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
-import org.springframework.web.client.RestClientException;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.companieshouse.api.strikeoffobjections.common.ApiLogger;
 import uk.gov.companieshouse.api.strikeoffobjections.exception.ObjectionNotFoundException;
 import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClient;
 import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClientResponse;
+import uk.gov.companieshouse.api.strikeoffobjections.file.ObjectionsLinkKeys;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.ObjectionStatus;
@@ -30,7 +30,10 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
@@ -45,6 +48,7 @@ class ObjectionServiceTest {
     private static final String REQUEST_ID = "87654321";
     private static final String OBJECTION_ID = "87651234";
     private static final String REASON = "REASON";
+    private static final String ACCESS_URL = "/dummyUrl";
     private static final LocalDateTime MOCKED_TIME_STAMP = LocalDateTime.of(2020, 2,2, 0, 0);
 
     @Mock
@@ -102,7 +106,7 @@ class ObjectionServiceTest {
     }
 
     @Test
-    void patchObjectionDoesNotExistTest() {
+    void patchObjectionDoesNotExistTest() throws Exception {
         ObjectionPatch objectionPatch = new ObjectionPatch();
         objectionPatch.setReason(REASON);
         objectionPatch.setStatus(ObjectionStatus.OPEN);
@@ -111,6 +115,30 @@ class ObjectionServiceTest {
         assertThrows(ObjectionNotFoundException.class, () -> objectionService.patchObjection(REQUEST_ID, COMPANY_NUMBER, OBJECTION_ID, objectionPatch));
 
         verify(objectionRepository, times(0)).save(any());
+    }
+
+    @Test
+    public void canAddAnAttachment() throws Exception {
+        Objection existingObjection = new Objection();
+        existingObjection.setId(OBJECTION_ID);
+        when(fileTransferApiClient.upload(anyString(), any(MultipartFile.class))).thenReturn(Utils.getSuccessfulUploadResponse());
+        when(objectionRepository.findById(any())).thenReturn(Optional.of(existingObjection));
+        objectionService.addAttachment(REQUEST_ID, OBJECTION_ID, Utils.mockMultipartFile(), ACCESS_URL);
+        Optional<Attachment> entityAttachment = existingObjection
+                .getAttachments()
+                .stream()
+                .findAny();
+
+        assertTrue(entityAttachment.isPresent());
+        String linkUrl = entityAttachment.get().getLinks().getLink(ObjectionsLinkKeys.SELF);
+        String downloadUrl = entityAttachment.get().getLinks().getLink(ObjectionsLinkKeys.DOWNLOAD);
+        assertEquals(linkUrl + "/download", downloadUrl);
+        assertTrue(linkUrl.startsWith(ACCESS_URL));
+        assertFalse(linkUrl.endsWith(ACCESS_URL + "/"));
+        assertNotNull(entityAttachment.get().getId());
+
+        verify(objectionRepository).save(existingObjection);
+        verify(objectionRepository).findById(OBJECTION_ID);
     }
 
     @Test
@@ -128,7 +156,7 @@ class ObjectionServiceTest {
     }
 
     @Test
-    void getAttachmentsWhenObjectionDoesNotExistTest() {
+    void getAttachmentsWhenObjectionDoesNotExistTest() throws Exception {
         when(objectionRepository.findById(any())).thenReturn(Optional.empty());
 
         assertThrows(ObjectionNotFoundException.class, () -> objectionService.getAttachments(REQUEST_ID, COMPANY_NUMBER, OBJECTION_ID));
@@ -140,7 +168,7 @@ class ObjectionServiceTest {
     public void willThrowServiceExceptionIfUploadErrors() throws Exception {
         when(fileTransferApiClient.upload(anyString(), any(MultipartFile.class))).thenReturn(Utils.getUnsuccessfulUploadResponse());
         try {
-            objectionService.addAttachment(REQUEST_ID, Utils.mockMultipartFile());
+            objectionService.addAttachment(REQUEST_ID, OBJECTION_ID, Utils.mockMultipartFile(), ACCESS_URL);
             fail();
         } catch(ServiceException e) {
             assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.toString(), e.getMessage());
@@ -152,7 +180,7 @@ class ObjectionServiceTest {
         when(fileTransferApiClient.upload(anyString(), any(MultipartFile.class)))
                 .thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
         try {
-            objectionService.addAttachment(REQUEST_ID, Utils.mockMultipartFile());
+            objectionService.addAttachment(REQUEST_ID, OBJECTION_ID, Utils.mockMultipartFile(), ACCESS_URL);
             fail();
         } catch(HttpServerErrorException e) {
             assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.toString(), e.getMessage());
@@ -164,7 +192,7 @@ class ObjectionServiceTest {
         when(fileTransferApiClient.upload(anyString(), any(MultipartFile.class)))
                 .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
         try {
-            objectionService.addAttachment(REQUEST_ID, Utils.mockMultipartFile());
+            objectionService.addAttachment(REQUEST_ID, OBJECTION_ID, Utils.mockMultipartFile(), ACCESS_URL);
             fail();
         } catch(HttpClientErrorException e) {
             assertEquals(HttpStatus.BAD_REQUEST.toString(), e.getMessage());
@@ -179,7 +207,7 @@ class ObjectionServiceTest {
                 .thenReturn(response);
 
         assertThrows(ServiceException.class, () ->
-                objectionService.addAttachment(REQUEST_ID, Utils.mockMultipartFile()));
+                objectionService.addAttachment(REQUEST_ID, OBJECTION_ID, Utils.mockMultipartFile(), ACCESS_URL));
 
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
@@ -127,7 +127,7 @@ class ObjectionServiceTest {
         when(objectionRepository.findById(any())).thenReturn(Optional.of(existingObjection));
         ServiceResult<String> attachmentIdResult =
                 objectionService.addAttachment(REQUEST_ID, OBJECTION_ID, Utils.mockMultipartFile(), ACCESS_URL);
-        assertEquals(Utils.ORIGINAL_FILE_NAME, attachmentIdResult.getData());
+        assertEquals(Utils.UPLOAD_ID, attachmentIdResult.getData());
         Optional<Attachment> entityAttachment = existingObjection
                 .getAttachments()
                 .stream()
@@ -149,7 +149,10 @@ class ObjectionServiceTest {
     public void willNotOverrideAlreadyExistingAttachments() throws Exception {
         Objection existingObjection = new Objection();
         existingObjection.setId(OBJECTION_ID);
-        when(fileTransferApiClient.upload(anyString(), any(MultipartFile.class))).thenReturn(Utils.getSuccessfulUploadResponse());
+
+        when(fileTransferApiClient.upload(anyString(), any(MultipartFile.class)))
+                .thenReturn(Utils.getSuccessfulUploadResponse());
+
         Attachment attachment = new Attachment();
         attachment.setSize(1L);
         attachment.setContentType("text/plain");
@@ -167,7 +170,6 @@ class ObjectionServiceTest {
 
         List<Attachment> objectionAttachments = existingObjection.getAttachments();
 
-        assertEquals(newId, attachmentIdResult.getData());
         assertEquals(2, objectionAttachments.size());
         assertEquals("testFile", objectionAttachments.get(0).getName());
         assertEquals(Utils.ORIGINAL_FILE_NAME, objectionAttachments.get(1).getName());

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/utils/Utils.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/utils/Utils.java
@@ -13,7 +13,7 @@ import java.nio.file.Files;
 public class Utils {
 
     public static final String ORIGINAL_FILE_NAME = "original.png";
-    private static final String UPLOAD_ID = "5agf-g6hh";
+    public static final String UPLOAD_ID = "5agf-g6hh";
 
     public static MultipartFile mockMultipartFile() throws IOException {
         String fileName = "testMultipart.txt";


### PR DESCRIPTION
Add the attchment to the mongo database following upload.
New unit tests.
Now returns no content when successful.