### PR TITLE
OBJ-70 Tomcat default upload is 1mb. Setting to 6mb.

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.data.mongodb.uri=${MONGODB_URL}/strike_off_objections
+
+spring.servlet.multipart.max-file-size=${UPLOAD_MAX_FILE_SIZE}
+spring.servlet.multipart.max-request-size=${UPLOAD_MAX_REQUEST_SIZE}


### PR DESCRIPTION
Setting max upload size to 6mb. File-transfer-api is limited to 4mb so this should give it some headroom and block stupidly large files.
6mb will be set in the config.