### PR TITLE
OBJ-134 File Transfer Api call for delete

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
@@ -49,6 +49,7 @@ public class ObjectionController {
     private static final String ERIC_AUTHORISED_USER = "ERIC-Authorised-User";
     private static final String OBJECTION_NOT_FOUND = "Objection not found";
     private static final String ATTACHMENT_NOT_FOUND = "Attachment not found";
+    public static final String COULD_NOT_DELETE = "Could not delete attachment";
 
     private PluggableResponseEntityFactory responseEntityFactory;
     private IObjectionService objectionService;
@@ -336,6 +337,17 @@ public class ObjectionController {
             );
 
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+
+        } catch(ServiceException e) {
+
+            apiLogger.errorContext(
+                    requestId,
+                    COULD_NOT_DELETE,
+                    e,
+                    logMap
+            );
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+
         } finally {
             apiLogger.infoContext(
                     requestId,

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
@@ -316,7 +316,7 @@ public class ObjectionController {
         );
 
         try {
-            objectionService.deleteAttachment(requestId, companyNumber, objectionId, attachmentId);
+            objectionService.deleteAttachment(requestId, objectionId, attachmentId);
 
             return ResponseEntity.noContent().build();
         } catch (ObjectionNotFoundException e) {

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
@@ -25,6 +25,6 @@ public interface IObjectionService {
     ServiceResult<String> addAttachment(String requestId, String objectionId, MultipartFile file, String attachmentsUri)
             throws ServiceException, ObjectionNotFoundException;
 
-    void deleteAttachment(String requestId, String companyNumber, String objectionId, String attachmentId)
+    void deleteAttachment(String requestId, String objectionId, String attachmentId)
             throws ObjectionNotFoundException, AttachmentNotFoundException, ServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
@@ -26,5 +26,5 @@ public interface IObjectionService {
             throws ServiceException, ObjectionNotFoundException;
 
     void deleteAttachment(String requestId, String companyNumber, String objectionId, String attachmentId)
-            throws ObjectionNotFoundException, AttachmentNotFoundException;
+            throws ObjectionNotFoundException, AttachmentNotFoundException, ServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
@@ -40,8 +40,8 @@ public class ObjectionService implements IObjectionService {
 
     private static final String OBJECTION_NOT_FOUND_MESSAGE = "Objection with id: %s, not found";
     private static final String ATTACHMENT_NOT_FOUND_MESSAGE = "Attachment with id: %s, not found";
-    private static final String DELETE_ERROR_MESSAGE = "Unable to delete attachment %s, status code %s";
-    private static final String DELETE_ERROR_MESSAGE_SHORT = "Unable to delete attachment %s";
+    private static final String DELETE_ATTACHMENT_MESSAGE = "Unable to delete attachment %s, status code %s";
+    private static final String DELETE_ATTACHMENT_MESSAGE_SHORT = "Unable to delete attachment %s";
 
     private ObjectionRepository objectionRepository;
     private ApiLogger logger;
@@ -209,19 +209,19 @@ public class ObjectionService implements IObjectionService {
         try {
             FileTransferApiClientResponse response = fileTransferApiClient.delete(requestId, attachmentId);
             if (response == null || response.getHttpStatus() == null) {
-                String message = String.format(DELETE_ERROR_MESSAGE_SHORT, attachmentId);
+                String message = String.format(DELETE_ATTACHMENT_MESSAGE_SHORT, attachmentId);
                 logger.infoContext(requestId, message, logMap);
                 throw new ServiceException(message);
             } else {
                 if (response.getHttpStatus().isError()) {
-                    String message = String.format(DELETE_ERROR_MESSAGE,
+                    String message = String.format(DELETE_ATTACHMENT_MESSAGE,
                             attachmentId, response.getHttpStatus());
                     logger.infoContext(requestId, message, logMap);
                     throw new ServiceException(message);
                 }
             }
         } catch (HttpClientErrorException | HttpServerErrorException e) {
-            String message = String.format(DELETE_ERROR_MESSAGE, attachmentId, e.getStatusCode());
+            String message = String.format(DELETE_ATTACHMENT_MESSAGE, attachmentId, e.getStatusCode());
             logger.errorContext(requestId, message, e, logMap);
             throw new ServiceException(message);
         }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
@@ -40,8 +40,8 @@ public class ObjectionService implements IObjectionService {
 
     private static final String OBJECTION_NOT_FOUND_MESSAGE = "Objection with id: %s, not found";
     private static final String ATTACHMENT_NOT_FOUND_MESSAGE = "Attachment with id: %s, not found";
-    private static final String DELETE_ATTACHMENT_MESSAGE = "Unable to delete attachment %s, status code %s";
-    private static final String DELETE_ATTACHMENT_MESSAGE_SHORT = "Unable to delete attachment %s";
+    private static final String ATTACHMENT_NOT_DELETED = "Unable to delete attachment %s, status code %s";
+    private static final String ATTACHMENT_NOT_DELETED_SHORT = "Unable to delete attachment %s";
 
     private ObjectionRepository objectionRepository;
     private ApiLogger logger;
@@ -209,19 +209,19 @@ public class ObjectionService implements IObjectionService {
         try {
             FileTransferApiClientResponse response = fileTransferApiClient.delete(requestId, attachmentId);
             if (response == null || response.getHttpStatus() == null) {
-                String message = String.format(DELETE_ATTACHMENT_MESSAGE_SHORT, attachmentId);
+                String message = String.format(ATTACHMENT_NOT_DELETED_SHORT, attachmentId);
                 logger.infoContext(requestId, message, logMap);
                 throw new ServiceException(message);
             } else {
                 if (response.getHttpStatus().isError()) {
-                    String message = String.format(DELETE_ATTACHMENT_MESSAGE,
+                    String message = String.format(ATTACHMENT_NOT_DELETED,
                             attachmentId, response.getHttpStatus());
                     logger.infoContext(requestId, message, logMap);
                     throw new ServiceException(message);
                 }
             }
         } catch (HttpClientErrorException | HttpServerErrorException e) {
-            String message = String.format(DELETE_ATTACHMENT_MESSAGE, attachmentId, e.getStatusCode());
+            String message = String.format(ATTACHMENT_NOT_DELETED, attachmentId, e.getStatusCode());
             logger.errorContext(requestId, message, e, logMap);
             throw new ServiceException(message);
         }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
@@ -227,6 +227,7 @@ public class ObjectionService implements IObjectionService {
         }
     }
 
+    // TODO OBJ-141 repetitive logging in codebase, needs centralized handler that allows for different parameters.
     private Map<String, Object> buildLogMap(String companyNumber, String objectionId, String attachmentId) {
         Map<String, Object> logMap = new HashMap<>();
         if(StringUtils.isNotBlank(companyNumber)) {

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
@@ -299,7 +299,7 @@ class ObjectionControllerTest {
     @Test
     public void deleteAttachmentWhenObjectionNotFoundTest()
             throws ObjectionNotFoundException, AttachmentNotFoundException, ServiceException {
-        doThrow(new ObjectionNotFoundException("Message")).when(objectionService).deleteAttachment(any(), any(), any(), any());
+        doThrow(new ObjectionNotFoundException("Message")).when(objectionService).deleteAttachment(any(), any(), any());
         ResponseEntity response = objectionController.deleteAttachment(COMPANY_NUMBER, OBJECTION_ID, ATTACHMENT_ID, REQUEST_ID);
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
@@ -309,7 +309,7 @@ class ObjectionControllerTest {
     @Test
     public void deleteAttachmentWhenAttachmentNotFoundTest()
             throws ObjectionNotFoundException, AttachmentNotFoundException, ServiceException {
-        doThrow(new AttachmentNotFoundException("Message")).when(objectionService).deleteAttachment(any(), any(), any(), any());
+        doThrow(new AttachmentNotFoundException("Message")).when(objectionService).deleteAttachment(any(), any(), any());
         ResponseEntity response = objectionController.deleteAttachment(COMPANY_NUMBER, OBJECTION_ID, ATTACHMENT_ID, REQUEST_ID);
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
@@ -319,7 +319,7 @@ class ObjectionControllerTest {
     @Test
     public void deleteAttachmentWhenUnableToDelete()
             throws ObjectionNotFoundException, AttachmentNotFoundException, ServiceException {
-        doThrow(new ServiceException("Message")).when(objectionService).deleteAttachment(any(), any(), any(), any());
+        doThrow(new ServiceException("Message")).when(objectionService).deleteAttachment(any(), any(), any());
         ResponseEntity response = objectionController.deleteAttachment(COMPANY_NUMBER, OBJECTION_ID, ATTACHMENT_ID, REQUEST_ID);
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
@@ -297,7 +297,8 @@ class ObjectionControllerTest {
     }
 
     @Test
-    public void deleteAttachmentWhenObjectionNotFoundTest() throws ObjectionNotFoundException, AttachmentNotFoundException {
+    public void deleteAttachmentWhenObjectionNotFoundTest()
+            throws ObjectionNotFoundException, AttachmentNotFoundException, ServiceException {
         doThrow(new ObjectionNotFoundException("Message")).when(objectionService).deleteAttachment(any(), any(), any(), any());
         ResponseEntity response = objectionController.deleteAttachment(COMPANY_NUMBER, OBJECTION_ID, ATTACHMENT_ID, REQUEST_ID);
 
@@ -306,11 +307,22 @@ class ObjectionControllerTest {
     }
 
     @Test
-    public void deleteAttachmentWhenAttachmentNotFoundTest() throws ObjectionNotFoundException, AttachmentNotFoundException {
+    public void deleteAttachmentWhenAttachmentNotFoundTest()
+            throws ObjectionNotFoundException, AttachmentNotFoundException, ServiceException {
         doThrow(new AttachmentNotFoundException("Message")).when(objectionService).deleteAttachment(any(), any(), any(), any());
         ResponseEntity response = objectionController.deleteAttachment(COMPANY_NUMBER, OBJECTION_ID, ATTACHMENT_ID, REQUEST_ID);
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+
+    }
+
+    @Test
+    public void deleteAttachmentWhenUnableToDelete()
+            throws ObjectionNotFoundException, AttachmentNotFoundException, ServiceException {
+        doThrow(new ServiceException("Message")).when(objectionService).deleteAttachment(any(), any(), any(), any());
+        ResponseEntity response = objectionController.deleteAttachment(COMPANY_NUMBER, OBJECTION_ID, ATTACHMENT_ID, REQUEST_ID);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
 
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiClientUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/file/FileTransferApiClientUnitTest.java
@@ -56,7 +56,7 @@ public class FileTransferApiClientUnitTest {
     }
 
     @Test
-    public void testUpload_success() {
+    public void testUploadSuccess() {
         final ResponseEntity<FileTransferApiResponse> apiResponse = apiSuccessResponse();
 
         when(restTemplate.postForEntity(eq(DUMMY_URL), any(), eq(FileTransferApiResponse.class)))
@@ -69,7 +69,7 @@ public class FileTransferApiClientUnitTest {
     }
 
     @Test
-    public void testUpload_ApiReturnsError() {
+    public void testUploadApiReturnsError() {
         final ResponseEntity<FileTransferApiResponse> apiErrorResponse = apiErrorResponse();
 
         when(restTemplate.postForEntity(eq(DUMMY_URL), any(), eq(FileTransferApiResponse.class))).thenReturn(apiErrorResponse);
@@ -82,7 +82,7 @@ public class FileTransferApiClientUnitTest {
     }
 
     @Test
-    public void testUpload_GenericExceptionResponse() {
+    public void testUploadGenericExceptionResponse() {
         final RestClientException exception = new RestClientException(EXCEPTION_MESSAGE);
 
         when(restTemplate.postForEntity(eq(DUMMY_URL), any(), eq(FileTransferApiResponse.class))).thenThrow(exception);
@@ -94,7 +94,7 @@ public class FileTransferApiClientUnitTest {
     }
 
     @Test
-    public void testDelete_success() {
+    public void testDeleteSuccess() {
         final ResponseEntity<String> apiResponse = new ResponseEntity<>("", HttpStatus.NO_CONTENT);
         when(restTemplate.exchange(eq(DELETE_URL), eq(HttpMethod.DELETE), any(), eq(String.class)))
                 .thenReturn(apiResponse);
@@ -103,7 +103,7 @@ public class FileTransferApiClientUnitTest {
     }
 
     @Test
-    public void testDelete_ApiReturnsError() {
+    public void testDeleteApiReturnsError() {
         final ResponseEntity<String> apiResponse = new ResponseEntity<>("", HttpStatus.INTERNAL_SERVER_ERROR);
 
         when(restTemplate.exchange(eq(DELETE_URL), eq(HttpMethod.DELETE), any(), eq(String.class)))
@@ -116,7 +116,7 @@ public class FileTransferApiClientUnitTest {
     }
 
     @Test
-    public void testDelete_GenericExceptionResponse() {
+    public void testDeleteGenericExceptionResponse() {
         final RestClientException exception = new RestClientException(EXCEPTION_MESSAGE);
 
         when(restTemplate.exchange(eq(DELETE_URL), eq(HttpMethod.DELETE), any(), eq(String.class))).thenThrow(exception);

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
@@ -317,7 +317,6 @@ class ObjectionServiceTest {
         when(fileTransferApiClient.delete(REQUEST_ID, ATTACHMENT_ID)).thenReturn(Utils.getSuccessfulDeleteResponse());
         objectionService.deleteAttachment(
                 REQUEST_ID,
-                COMPANY_NUMBER,
                 OBJECTION_ID,
                 ATTACHMENT_ID
         );
@@ -333,7 +332,6 @@ class ObjectionServiceTest {
         when(objectionRepository.findById(any())).thenReturn(Optional.empty());
         assertThrows(ObjectionNotFoundException.class, () -> objectionService.deleteAttachment(
                 REQUEST_ID,
-                COMPANY_NUMBER,
                 OBJECTION_ID,
                 ATTACHMENT_ID
                 )
@@ -346,7 +344,6 @@ class ObjectionServiceTest {
         when(objectionRepository.findById(any())).thenReturn(Optional.of(objection));
         assertThrows(AttachmentNotFoundException.class, () -> objectionService.deleteAttachment(
                 REQUEST_ID,
-                COMPANY_NUMBER,
                 OBJECTION_ID,
                 ATTACHMENT_ID
                 )
@@ -369,7 +366,6 @@ class ObjectionServiceTest {
 
         assertThrows(ServiceException.class, () -> objectionService.deleteAttachment(
                 REQUEST_ID,
-                COMPANY_NUMBER,
                 OBJECTION_ID,
                 ATTACHMENT_ID
             )
@@ -401,7 +397,6 @@ class ObjectionServiceTest {
 
         assertThrows(ServiceException.class, () -> objectionService.deleteAttachment(
                 REQUEST_ID,
-                COMPANY_NUMBER,
                 OBJECTION_ID,
                 ATTACHMENT_ID
             )
@@ -431,7 +426,6 @@ class ObjectionServiceTest {
 
         assertThrows(ServiceException.class, () -> objectionService.deleteAttachment(
                 REQUEST_ID,
-                COMPANY_NUMBER,
                 OBJECTION_ID,
                 ATTACHMENT_ID
             )
@@ -461,7 +455,6 @@ class ObjectionServiceTest {
 
         assertThrows(ServiceException.class, () -> objectionService.deleteAttachment(
                 REQUEST_ID,
-                COMPANY_NUMBER,
                 OBJECTION_ID,
                 ATTACHMENT_ID
             )
@@ -493,7 +486,6 @@ class ObjectionServiceTest {
 
         assertThrows(ServiceException.class, () -> objectionService.deleteAttachment(
                 REQUEST_ID,
-                COMPANY_NUMBER,
                 OBJECTION_ID,
                 ATTACHMENT_ID
             )

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
@@ -39,6 +39,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -211,7 +213,7 @@ class ObjectionServiceTest {
 
     @Test
     public void willThrowServiceExceptionIfUploadErrors() throws Exception {
-        when(fileTransferApiClient.upload(anyString(), any(MultipartFile.class))).thenReturn(Utils.getUnsuccessfulUploadResponse());
+        when(fileTransferApiClient.upload(anyString(), any(MultipartFile.class))).thenReturn(Utils.getUnsuccessfulFileTransferApiResponse());
         try {
             objectionService.addAttachment(REQUEST_ID, OBJECTION_ID, Utils.mockMultipartFile(), ACCESS_URL);
             fail();
@@ -312,7 +314,7 @@ class ObjectionServiceTest {
         attachment.setId(ATTACHMENT_ID);
         existingObjection.addAttachment(attachment);
         when(objectionRepository.findById(any())).thenReturn(Optional.of(existingObjection));
-
+        when(fileTransferApiClient.delete(REQUEST_ID, ATTACHMENT_ID)).thenReturn(Utils.getSuccessfulDeleteResponse());
         objectionService.deleteAttachment(
                 REQUEST_ID,
                 COMPANY_NUMBER,
@@ -321,6 +323,7 @@ class ObjectionServiceTest {
         );
 
         verify(objectionRepository, times(1)).save(existingObjection);
+        verify(fileTransferApiClient, times(1)).delete(REQUEST_ID, ATTACHMENT_ID);
         assertFalse(existingObjection.getAttachments().contains(attachment));
     }
 
@@ -328,7 +331,6 @@ class ObjectionServiceTest {
     void deleteAttachmentTestWhenObjectionDoesNotExist() {
 
         when(objectionRepository.findById(any())).thenReturn(Optional.empty());
-
         assertThrows(ObjectionNotFoundException.class, () -> objectionService.deleteAttachment(
                 REQUEST_ID,
                 COMPANY_NUMBER,
@@ -340,10 +342,8 @@ class ObjectionServiceTest {
 
     @Test
     void deleteAttachmentTestAttachmentDoesNotExist() {
-
         Objection objection = new Objection();
         when(objectionRepository.findById(any())).thenReturn(Optional.of(objection));
-
         assertThrows(AttachmentNotFoundException.class, () -> objectionService.deleteAttachment(
                 REQUEST_ID,
                 COMPANY_NUMBER,
@@ -352,4 +352,159 @@ class ObjectionServiceTest {
                 )
         );
     }
+
+    @Test
+    void deleteAttachmentHandleClientExceptionFromS3()
+            throws ObjectionNotFoundException, AttachmentNotFoundException {
+        Objection objection = Utils.getTestObjection(OBJECTION_ID);
+        Utils.getTestAttachments(ATTACHMENT_ID).stream().forEach(
+            attachment -> {
+                objection.addAttachment(attachment);
+            }
+        );
+
+        HttpServerErrorException clientException = new HttpServerErrorException(HttpStatus.BAD_REQUEST);
+        when(fileTransferApiClient.delete(REQUEST_ID, ATTACHMENT_ID)).thenThrow(clientException);
+        when(objectionRepository.findById(objection.getId()))
+                .thenReturn(Optional.of(objection));
+
+        objectionService.deleteAttachment(
+                REQUEST_ID,
+                COMPANY_NUMBER,
+                OBJECTION_ID,
+                ATTACHMENT_ID
+        );
+
+        verify(objectionRepository, never()).save(objection);
+        verify(fileTransferApiClient, times(1)).delete(REQUEST_ID, ATTACHMENT_ID);
+        verify(apiLogger).errorContext(
+                eq(REQUEST_ID),
+                eq(String.format("Unable to delete attachment %s, status code 400 BAD_REQUEST", ATTACHMENT_ID)),
+                eq(clientException),
+                any());
+    }
+
+    @Test
+    void deleteAttachmentHandleServiceExceptionFromS3()
+            throws ObjectionNotFoundException, AttachmentNotFoundException {
+
+        Objection objection = Utils.getTestObjection(OBJECTION_ID);
+        Utils.getTestAttachments(ATTACHMENT_ID).stream().forEach(
+            attachment -> {
+                objection.addAttachment(attachment);
+            }
+        );
+
+        HttpServerErrorException serviceException = new HttpServerErrorException(HttpStatus.GATEWAY_TIMEOUT);
+        when(fileTransferApiClient.delete(REQUEST_ID, ATTACHMENT_ID)).thenThrow(serviceException);
+        when(objectionRepository.findById(objection.getId()))
+                .thenReturn(Optional.of(objection));
+
+        objectionService.deleteAttachment(
+                REQUEST_ID,
+                COMPANY_NUMBER,
+                OBJECTION_ID,
+                ATTACHMENT_ID
+        );
+        verify(objectionRepository, never()).save(objection);
+        verify(fileTransferApiClient, times(1)).delete(REQUEST_ID, ATTACHMENT_ID);
+        verify(apiLogger).errorContext(
+                eq(REQUEST_ID),
+                eq(String.format("Unable to delete attachment %s, status code 504 GATEWAY_TIMEOUT", ATTACHMENT_ID)),
+                eq(serviceException),
+                any());
+    }
+
+    @Test
+    public void deleteAttachmentHandleHttpErrorCodeInFileTransferResponse()
+            throws ObjectionNotFoundException, AttachmentNotFoundException {
+        Objection objection = Utils.getTestObjection(OBJECTION_ID);
+        Utils.getTestAttachments(ATTACHMENT_ID).stream().forEach(
+            attachment -> {
+                objection.addAttachment(attachment);
+            }
+        );
+
+        when(fileTransferApiClient.delete(REQUEST_ID, ATTACHMENT_ID)).thenReturn(Utils.getUnsuccessfulFileTransferApiResponse());
+
+        when(objectionRepository.findById(objection.getId()))
+                .thenReturn(Optional.of(objection));
+
+        objectionService.deleteAttachment(
+                REQUEST_ID,
+                COMPANY_NUMBER,
+                OBJECTION_ID,
+                ATTACHMENT_ID
+        );
+
+        verify(objectionRepository, never()).save(objection);
+        verify(fileTransferApiClient, times(1)).delete(REQUEST_ID, ATTACHMENT_ID);
+        verify(apiLogger).infoContext(
+                eq(REQUEST_ID),
+                eq(String.format("Unable to delete attachment %s, status code 500 INTERNAL_SERVER_ERROR", ATTACHMENT_ID)),
+                any());
+    }
+
+    @Test
+    public void deleteAttachmentHandleNullApiResponseOnDeleteAttachment()
+            throws ObjectionNotFoundException, AttachmentNotFoundException {
+        Objection objection = Utils.getTestObjection(OBJECTION_ID);
+        Utils.getTestAttachments(ATTACHMENT_ID).stream().forEach(
+            attachment -> {
+                objection.addAttachment(attachment);
+            }
+        );
+
+        when(fileTransferApiClient.delete(REQUEST_ID, ATTACHMENT_ID)).thenReturn(null);
+
+        when(objectionRepository.findById(objection.getId()))
+                .thenReturn(Optional.of(objection));
+
+        objectionService.deleteAttachment(
+                REQUEST_ID,
+                COMPANY_NUMBER,
+                OBJECTION_ID,
+                ATTACHMENT_ID
+        );
+
+        verify(objectionRepository, never()).save(objection);
+        verify(fileTransferApiClient, times(1)).delete(REQUEST_ID, ATTACHMENT_ID);
+        verify(apiLogger).infoContext(
+                eq(REQUEST_ID),
+                eq(String.format("Unable to delete attachment %s", ATTACHMENT_ID)),
+                any());
+    }
+
+    @Test
+    public void deleteAttachmentHandleNullHttpStatusApiResponseOnDeleteAttachment()
+            throws ObjectionNotFoundException, AttachmentNotFoundException {
+        Objection objection = Utils.getTestObjection(OBJECTION_ID);
+        Utils.getTestAttachments(ATTACHMENT_ID).stream().forEach(
+            attachment -> {
+                objection.addAttachment(attachment);
+            }
+        );
+
+        FileTransferApiClientResponse response = new FileTransferApiClientResponse();
+        response.setHttpStatus(null);
+        when(fileTransferApiClient.delete(REQUEST_ID, ATTACHMENT_ID)).thenReturn(response);
+
+        when(objectionRepository.findById(objection.getId()))
+                .thenReturn(Optional.of(objection));
+
+        objectionService.deleteAttachment(
+                REQUEST_ID,
+                COMPANY_NUMBER,
+                OBJECTION_ID,
+                ATTACHMENT_ID
+        );
+
+        verify(objectionRepository, never()).save(objection);
+        verify(fileTransferApiClient, times(1)).delete(REQUEST_ID, ATTACHMENT_ID);
+        verify(apiLogger).infoContext(
+                eq(REQUEST_ID),
+                eq(String.format("Unable to delete attachment %s", ATTACHMENT_ID)),
+                any());
+    }
+
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
@@ -307,7 +307,7 @@ class ObjectionServiceTest {
     }
 
     @Test
-    void deleteAttachmentTest() throws ObjectionNotFoundException, AttachmentNotFoundException {
+    void deleteAttachmentTest() throws ObjectionNotFoundException, AttachmentNotFoundException, ServiceException {
         Objection existingObjection = new Objection();
         existingObjection.setId(OBJECTION_ID);
         Attachment attachment = new Attachment();
@@ -354,8 +354,7 @@ class ObjectionServiceTest {
     }
 
     @Test
-    void deleteAttachmentHandleClientExceptionFromS3()
-            throws ObjectionNotFoundException, AttachmentNotFoundException {
+    void deleteAttachmentHandleClientExceptionFromS3() {
         Objection objection = Utils.getTestObjection(OBJECTION_ID);
         Utils.getTestAttachments(ATTACHMENT_ID).stream().forEach(
             attachment -> {
@@ -368,11 +367,12 @@ class ObjectionServiceTest {
         when(objectionRepository.findById(objection.getId()))
                 .thenReturn(Optional.of(objection));
 
-        objectionService.deleteAttachment(
+        assertThrows(ServiceException.class, () -> objectionService.deleteAttachment(
                 REQUEST_ID,
                 COMPANY_NUMBER,
                 OBJECTION_ID,
                 ATTACHMENT_ID
+            )
         );
 
         verify(objectionRepository, never()).save(objection);
@@ -385,8 +385,7 @@ class ObjectionServiceTest {
     }
 
     @Test
-    void deleteAttachmentHandleServiceExceptionFromS3()
-            throws ObjectionNotFoundException, AttachmentNotFoundException {
+    void deleteAttachmentHandleServiceExceptionFromS3() {
 
         Objection objection = Utils.getTestObjection(OBJECTION_ID);
         Utils.getTestAttachments(ATTACHMENT_ID).stream().forEach(
@@ -400,11 +399,12 @@ class ObjectionServiceTest {
         when(objectionRepository.findById(objection.getId()))
                 .thenReturn(Optional.of(objection));
 
-        objectionService.deleteAttachment(
+        assertThrows(ServiceException.class, () -> objectionService.deleteAttachment(
                 REQUEST_ID,
                 COMPANY_NUMBER,
                 OBJECTION_ID,
                 ATTACHMENT_ID
+            )
         );
         verify(objectionRepository, never()).save(objection);
         verify(fileTransferApiClient, times(1)).delete(REQUEST_ID, ATTACHMENT_ID);
@@ -416,8 +416,7 @@ class ObjectionServiceTest {
     }
 
     @Test
-    public void deleteAttachmentHandleHttpErrorCodeInFileTransferResponse()
-            throws ObjectionNotFoundException, AttachmentNotFoundException {
+    public void deleteAttachmentHandleHttpErrorCodeInFileTransferResponse() {
         Objection objection = Utils.getTestObjection(OBJECTION_ID);
         Utils.getTestAttachments(ATTACHMENT_ID).stream().forEach(
             attachment -> {
@@ -430,11 +429,12 @@ class ObjectionServiceTest {
         when(objectionRepository.findById(objection.getId()))
                 .thenReturn(Optional.of(objection));
 
-        objectionService.deleteAttachment(
+        assertThrows(ServiceException.class, () -> objectionService.deleteAttachment(
                 REQUEST_ID,
                 COMPANY_NUMBER,
                 OBJECTION_ID,
                 ATTACHMENT_ID
+            )
         );
 
         verify(objectionRepository, never()).save(objection);
@@ -446,8 +446,7 @@ class ObjectionServiceTest {
     }
 
     @Test
-    public void deleteAttachmentHandleNullApiResponseOnDeleteAttachment()
-            throws ObjectionNotFoundException, AttachmentNotFoundException {
+    public void deleteAttachmentHandleNullApiResponseOnDeleteAttachment() {
         Objection objection = Utils.getTestObjection(OBJECTION_ID);
         Utils.getTestAttachments(ATTACHMENT_ID).stream().forEach(
             attachment -> {
@@ -460,11 +459,12 @@ class ObjectionServiceTest {
         when(objectionRepository.findById(objection.getId()))
                 .thenReturn(Optional.of(objection));
 
-        objectionService.deleteAttachment(
+        assertThrows(ServiceException.class, () -> objectionService.deleteAttachment(
                 REQUEST_ID,
                 COMPANY_NUMBER,
                 OBJECTION_ID,
                 ATTACHMENT_ID
+            )
         );
 
         verify(objectionRepository, never()).save(objection);
@@ -476,8 +476,7 @@ class ObjectionServiceTest {
     }
 
     @Test
-    public void deleteAttachmentHandleNullHttpStatusApiResponseOnDeleteAttachment()
-            throws ObjectionNotFoundException, AttachmentNotFoundException {
+    public void deleteAttachmentHandleNullHttpStatusApiResponseOnDeleteAttachment() {
         Objection objection = Utils.getTestObjection(OBJECTION_ID);
         Utils.getTestAttachments(ATTACHMENT_ID).stream().forEach(
             attachment -> {
@@ -492,11 +491,12 @@ class ObjectionServiceTest {
         when(objectionRepository.findById(objection.getId()))
                 .thenReturn(Optional.of(objection));
 
-        objectionService.deleteAttachment(
+        assertThrows(ServiceException.class, () -> objectionService.deleteAttachment(
                 REQUEST_ID,
                 COMPANY_NUMBER,
                 OBJECTION_ID,
                 ATTACHMENT_ID
+            )
         );
 
         verify(objectionRepository, never()).save(objection);

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/utils/Utils.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/utils/Utils.java
@@ -27,13 +27,13 @@ public class Utils {
 
     public static List<Attachment> getTestAttachments(String isContained) {
         List<Attachment> attachments = new ArrayList<Attachment>();
-        attachments.add(buildTestAttchemnt("123", "test1.txt"));
-        attachments.add(buildTestAttchemnt(isContained, "test2.txt"));
-        attachments.add(buildTestAttchemnt("abc", "test3.txt"));
+        attachments.add(buildTestAttachment("123", "test1.txt"));
+        attachments.add(buildTestAttachment(isContained, "test2.txt"));
+        attachments.add(buildTestAttachment("abc", "test3.txt"));
         return attachments;
     }
 
-    public static Attachment buildTestAttchemnt(String id, String name) {
+    public static Attachment buildTestAttachment(String id, String name) {
         Attachment attachment = new Attachment();
         attachment.setId(id);
         attachment.setName(name);

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/utils/Utils.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/utils/Utils.java
@@ -6,14 +6,39 @@ import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClientResponse;
+import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
+import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
 
 public class Utils {
 
     public static final String ORIGINAL_FILE_NAME = "original.png";
     public static final String UPLOAD_ID = "5agf-g6hh";
+
+    public static Objection getTestObjection(String id) {
+        Objection objection = new Objection();
+        objection.setId(id);
+        return objection;
+    }
+
+    public static List<Attachment> getTestAttachments(String isContained) {
+        List<Attachment> attachments = new ArrayList<Attachment>();
+        attachments.add(buildTestAttchemnt("123", "test1.txt"));
+        attachments.add(buildTestAttchemnt(isContained, "test2.txt"));
+        attachments.add(buildTestAttchemnt("abc", "test3.txt"));
+        return attachments;
+    }
+
+    public static Attachment buildTestAttchemnt(String id, String name) {
+        Attachment attachment = new Attachment();
+        attachment.setId(id);
+        attachment.setName(name);
+        return attachment;
+    }
 
     public static MultipartFile mockMultipartFile() throws IOException {
         String fileName = "testMultipart.txt";
@@ -28,7 +53,13 @@ public class Utils {
         return fileTransferApiClientResponse;
     }
 
-    public static FileTransferApiClientResponse getUnsuccessfulUploadResponse() {
+    public static FileTransferApiClientResponse getSuccessfulDeleteResponse() {
+        FileTransferApiClientResponse fileTransferApiClientResponse = new FileTransferApiClientResponse();
+        fileTransferApiClientResponse.setHttpStatus(HttpStatus.NO_CONTENT);
+        return fileTransferApiClientResponse;
+    }
+
+    public static FileTransferApiClientResponse getUnsuccessfulFileTransferApiResponse() {
         FileTransferApiClientResponse fileTransferApiClientResponse = new FileTransferApiClientResponse();
         fileTransferApiClientResponse.setHttpStatus(HttpStatus.INTERNAL_SERVER_ERROR);
         return fileTransferApiClientResponse;


### PR DESCRIPTION
Call to the file transfer api to removed the file from s3 will proceeed with deletion from mongo if s3 deletion is sucessful so as to avoid leaving the objection in an inconsistent state.

Added unit tests for the service and file transfer client.

