### PR TITLE
OBJ-227 Ineligible http code

### DIFF
--- a/spec/schema.json
+++ b/spec/schema.json
@@ -409,25 +409,20 @@
         }
       }
     },
+    "Ineligible": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/Status"
+        }
+      }
+    },
     "Status": {
       "type": "string",
       "enum": [
         "OPEN",
         "SUBMITTED",
-        "PROCESSED"
-      ]
-    },
-    "Ineligible": {
-      "type": "object",
-      "properties": {
-        "status": {
-          "$ref": "#/definitions/IneligibilityStatus"
-        }
-      }
-    },
-    "IneligibilityStatus": {
-      "type": "string",
-      "enum": [
+        "PROCESSED",
         "INELIGIBLE_COMPANY_STRUCK_OFF",
         "INELIGIBLE_NO_DISSOLUTION_ACTION"
       ]

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -429,9 +429,7 @@
       "type": "string",
       "enum": [
         "INELIGIBLE_COMPANY_STRUCK_OFF",
-        "INELIGIBLE_COMPANY_SECOND_GAZETTE",
-        "INELIGIBLE_COMPANY_CONVERTED",
-        "INELIGIBLE_COMPANY_NO_ELIGIBILITY_CODE"
+        "INELIGIBLE_NO_DISSOLUTION_ACTION"
       ]
     }
   }

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -54,7 +54,7 @@
               "$ref": "#/definitions/ResourceCreated"
             }
           },
-          "406": {
+          "400": {
             "description": "Company was ineligible for objecting to strike off",
             "schema": {
               "$ref": "#/definitions/Ineligible"

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -55,7 +55,7 @@
             }
           },
           "400": {
-            "description": "Company was ineligible for objecting to strike off",
+            "description": "Company is ineligible for objecting to strike off",
             "schema": {
               "$ref": "#/definitions/Ineligible"
             }

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -426,7 +426,9 @@
       "enum": [
         "OPEN",
         "SUBMITTED",
-        "PROCESSED"
+        "PROCESSED",
+        "INELIGIBLE_COMPANY_STRUCK_OFF",
+        "INELIGIBLE_NO_DISSOLUTION_ACTION"
       ]
     }
   }

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -53,6 +53,12 @@
             "schema": {
               "$ref": "#/definitions/ResourceCreated"
             }
+          },
+          "406": {
+            "description": "Company was ineligible for objecting to strike off",
+            "schema": {
+              "$ref": "#/definitions/Ineligible"
+            }
           }
         }
       }
@@ -409,6 +415,23 @@
         "OPEN",
         "SUBMITTED",
         "PROCESSED"
+      ]
+    },
+    "Ineligible": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/IneligibilityStatus"
+        }
+      }
+    },
+    "IneligibilityStatus": {
+      "type": "string",
+      "enum": [
+        "INELIGIBLE_COMPANY_STRUCK_OFF",
+        "INELIGIBLE_COMPANY_SECOND_GAZETTE",
+        "INELIGIBLE_COMPANY_CONVERTED",
+        "INELIGIBLE_COMPANY_NO_ELIGIBILITY_CODE"
       ]
     }
   }

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -413,7 +413,11 @@
       "type": "object",
       "properties": {
         "status": {
-          "$ref": "#/definitions/Status"
+          "type": "string",
+          "enum": [
+            "INELIGIBLE_COMPANY_STRUCK_OFF",
+            "INELIGIBLE_NO_DISSOLUTION_ACTION"
+          ]
         }
       }
     },
@@ -422,9 +426,7 @@
       "enum": [
         "OPEN",
         "SUBMITTED",
-        "PROCESSED",
-        "INELIGIBLE_COMPANY_STRUCK_OFF",
-        "INELIGIBLE_NO_DISSOLUTION_ACTION"
+        "PROCESSED"
       ]
     }
   }


### PR DESCRIPTION
When create is called and a company is not eligible an HTTP 406 code: NOT_ACEPTABLE is returned. One of 4 status is possible 3 corresponding to the ineligibility codes on OBJ-208 and 1 if no codes are present as described on OBJ-209.