### PR TITLE
OBJ-232 api controller return obj status for eligibility

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
@@ -146,7 +146,8 @@ public class ObjectionController {
         );
 
         try {
-            ObjectionResponseDTO response = objectionService.createObjection(requestId, companyNumber, ericUserId, ericUserDetails);
+            Objection objection = objectionService.createObjection(requestId, companyNumber, ericUserId, ericUserDetails);
+            ObjectionResponseDTO response = objectionMapper.objectionEntityToObjectionResponseDTO(objection);
             ObjectionStatus objectionStatus = response.getStatus();
             if (objectionStatus.isIneligible()) {
                return new ResponseEntity<>(ChResponseBody.createNormalBody(response), HttpStatus.BAD_REQUEST);

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
@@ -147,12 +147,13 @@ public class ObjectionController {
 
         try {
             Objection objection = objectionService.createObjection(requestId, companyNumber, ericUserId, ericUserDetails);
-            ObjectionResponseDTO response = objectionMapper.objectionEntityToObjectionResponseDTO(objection);
-            ObjectionStatus objectionStatus = response.getStatus();
+            ObjectionStatus objectionStatus = objection.getStatus();
             if (objectionStatus.isIneligible()) {
+               ObjectionResponseDTO response = new  ObjectionResponseDTO();
+               response.setStatus(objectionStatus);
                return new ResponseEntity<>(ChResponseBody.createNormalBody(response), HttpStatus.BAD_REQUEST);
             }
-            return responseEntityFactory.createResponse(ServiceResult.created(response));
+            return responseEntityFactory.createResponse(ServiceResult.created(new ObjectionResponseDTO(objection.getId())));
         } catch (Exception e) {
             apiLogger.errorContext(
                     requestId,

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
@@ -147,8 +147,8 @@ public class ObjectionController {
 
         try {
             ObjectionResponseDTO response = objectionService.createObjection(requestId, companyNumber, ericUserId, ericUserDetails);
-            ObjectionStatus obStat = response.getStatus();
-            if (obStat != null && obStat.isEligibilityError()) {
+            ObjectionStatus objectionStatus = response.getStatus();
+            if (objectionStatus != null && objectionStatus.isIneligibleStatus()) {
                return new ResponseEntity<>(ChResponseBody.createNormalBody(response), HttpStatus.BAD_REQUEST);
             }
             return responseEntityFactory.createResponse(ServiceResult.created(response));

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
@@ -23,6 +23,7 @@ import uk.gov.companieshouse.api.strikeoffobjections.exception.ObjectionNotFound
 import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClientResponse;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
+import uk.gov.companieshouse.api.strikeoffobjections.model.entity.ObjectionStatus;
 import uk.gov.companieshouse.api.strikeoffobjections.model.patch.ObjectionPatch;
 import uk.gov.companieshouse.api.strikeoffobjections.model.response.AttachmentResponseDTO;
 import uk.gov.companieshouse.api.strikeoffobjections.model.response.ObjectionResponseDTO;
@@ -145,8 +146,11 @@ public class ObjectionController {
         );
 
         try {
-            String objectionId = objectionService.createObjection(requestId, companyNumber, ericUserId, ericUserDetails);
-            ObjectionResponseDTO response = new ObjectionResponseDTO(objectionId);
+            ObjectionResponseDTO response = objectionService.createObjection(requestId, companyNumber, ericUserId, ericUserDetails);
+            ObjectionStatus obStat = response.getStatus();
+            if (obStat != null && obStat.isEligibilityError()) {
+               return new ResponseEntity<>(ChResponseBody.createNormalBody(response), HttpStatus.BAD_REQUEST);
+            }
             return responseEntityFactory.createResponse(ServiceResult.created(response));
         } catch (Exception e) {
             apiLogger.errorContext(

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
@@ -149,7 +149,7 @@ public class ObjectionController {
             Objection objection = objectionService.createObjection(requestId, companyNumber, ericUserId, ericUserDetails);
             ObjectionStatus objectionStatus = objection.getStatus();
             if (objectionStatus.isIneligible()) {
-               ObjectionResponseDTO response = new  ObjectionResponseDTO();
+               ObjectionResponseDTO response = new ObjectionResponseDTO();
                response.setStatus(objectionStatus);
                return new ResponseEntity<>(ChResponseBody.createNormalBody(response), HttpStatus.BAD_REQUEST);
             }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
@@ -148,7 +148,7 @@ public class ObjectionController {
         try {
             ObjectionResponseDTO response = objectionService.createObjection(requestId, companyNumber, ericUserId, ericUserDetails);
             ObjectionStatus objectionStatus = response.getStatus();
-            if (objectionStatus != null && objectionStatus.isIneligibleStatus()) {
+            if (objectionStatus.isIneligibleStatus()) {
                return new ResponseEntity<>(ChResponseBody.createNormalBody(response), HttpStatus.BAD_REQUEST);
             }
             return responseEntityFactory.createResponse(ServiceResult.created(response));

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
@@ -148,7 +148,7 @@ public class ObjectionController {
         try {
             ObjectionResponseDTO response = objectionService.createObjection(requestId, companyNumber, ericUserId, ericUserDetails);
             ObjectionStatus objectionStatus = response.getStatus();
-            if (objectionStatus.isIneligibleStatus()) {
+            if (objectionStatus.isIneligible()) {
                return new ResponseEntity<>(ChResponseBody.createNormalBody(response), HttpStatus.BAD_REQUEST);
             }
             return responseEntityFactory.createResponse(ServiceResult.created(response));

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/entity/ObjectionStatus.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/entity/ObjectionStatus.java
@@ -8,7 +8,7 @@ public enum ObjectionStatus {
     PROCESSED,
     SUBMITTED;
 
-    public boolean isIneligibleStatus() {
+    public boolean isIneligible() {
         return this == INELIGIBLE_NO_DISSOLUTION_ACTION ||
                 this == INELIGIBLE_COMPANY_STRUCK_OFF;
     }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/entity/ObjectionStatus.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/entity/ObjectionStatus.java
@@ -1,13 +1,14 @@
 package uk.gov.companieshouse.api.strikeoffobjections.model.entity;
 
 public enum ObjectionStatus {
+
+    INELIGIBLE_COMPANY_STRUCK_OFF,
+    INELIGIBLE_NO_DISSOLUTION_ACTION,
     OPEN,
     PROCESSED,
-    SUBMITTED,
-    INELIGIBLE_COMPANY_STRUCK_OFF,
-    INELIGIBLE_NO_DISSOLUTION_ACTION;
+    SUBMITTED;
 
-    public boolean isEligibilityError() {
+    public boolean isIneligibleStatus() {
         return this == INELIGIBLE_NO_DISSOLUTION_ACTION ||
                 this == INELIGIBLE_COMPANY_STRUCK_OFF;
     }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/entity/ObjectionStatus.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/entity/ObjectionStatus.java
@@ -5,5 +5,10 @@ public enum ObjectionStatus {
     PROCESSED,
     SUBMITTED,
     INELIGIBLE_COMPANY_STRUCK_OFF,
-    INELIGIBLE_NO_DISSOLUTION_ACTION
+    INELIGIBLE_NO_DISSOLUTION_ACTION;
+
+    public boolean isEligibilityError() {
+        return this == INELIGIBLE_NO_DISSOLUTION_ACTION ||
+                this == INELIGIBLE_COMPANY_STRUCK_OFF;
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
@@ -10,13 +10,14 @@ import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClientR
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
 import uk.gov.companieshouse.api.strikeoffobjections.model.patch.ObjectionPatch;
+import uk.gov.companieshouse.api.strikeoffobjections.model.response.ObjectionResponseDTO;
 import uk.gov.companieshouse.service.ServiceException;
 import uk.gov.companieshouse.service.ServiceResult;
 
 import javax.servlet.http.HttpServletResponse;
 
 public interface IObjectionService {
-    String createObjection(String requestId, String companyNumber, String ericUserId, String ericUserDetails);
+    ObjectionResponseDTO createObjection(String requestId, String companyNumber, String ericUserId, String ericUserDetails);
 
     void patchObjection(String objectionId, ObjectionPatch objectionPatch, String requestId, String companyNumber)
             throws ObjectionNotFoundException, InvalidObjectionStatusException, ServiceException;

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
@@ -17,7 +17,7 @@ import uk.gov.companieshouse.service.ServiceResult;
 import javax.servlet.http.HttpServletResponse;
 
 public interface IObjectionService {
-    ObjectionResponseDTO createObjection(String requestId, String companyNumber, String ericUserId, String ericUserDetails);
+    Objection createObjection(String requestId, String companyNumber, String ericUserId, String ericUserDetails);
 
     void patchObjection(String objectionId, ObjectionPatch objectionPatch, String requestId, String companyNumber)
             throws ObjectionNotFoundException, InvalidObjectionStatusException, ServiceException;

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
@@ -10,7 +10,6 @@ import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClientR
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
 import uk.gov.companieshouse.api.strikeoffobjections.model.patch.ObjectionPatch;
-import uk.gov.companieshouse.api.strikeoffobjections.model.response.ObjectionResponseDTO;
 import uk.gov.companieshouse.service.ServiceException;
 import uk.gov.companieshouse.service.ServiceResult;
 

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
@@ -79,7 +79,7 @@ public class ObjectionService implements IObjectionService {
         ObjectionResponseDTO response = new ObjectionResponseDTO();
 
         // TODO OBJ-231 process query result and return eligibility status
-        ObjectionStatus obStat = ObjectionStatus.OPEN;
+        ObjectionStatus objectionStatus = ObjectionStatus.OPEN;
 
         final String userEmailAddress = ericHeaderParser.getEmailAddress(ericUserDetails);
 
@@ -88,7 +88,7 @@ public class ObjectionService implements IObjectionService {
                 .withCreatedOn(dateTimeSupplier.get())
                 .withCreatedBy(new CreatedBy(ericUserId, userEmailAddress))
                 .withHttpRequestId(requestId)
-                .withStatus(obStat)
+                .withStatus(objectionStatus)
                 .build();
 
         Objection savedEntity = objectionRepository.save(entity);

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
@@ -73,7 +73,7 @@ public class ObjectionService implements IObjectionService {
     }
 
     @Override
-    public ObjectionResponseDTO createObjection(String requestId, String companyNumber, String ericUserId, String ericUserDetails) {
+    public Objection createObjection(String requestId, String companyNumber, String ericUserId, String ericUserDetails) {
         Map<String, Object> logMap = buildLogMap(companyNumber, null, null);
         logger.infoContext(requestId, "Creating objection", logMap);
         ObjectionResponseDTO response = new ObjectionResponseDTO();
@@ -92,9 +92,8 @@ public class ObjectionService implements IObjectionService {
                 .build();
 
         Objection savedEntity = objectionRepository.save(entity);
-        response.setId(savedEntity.getId());
-        response.setStatus(savedEntity.getStatus());
-        return response;
+
+        return savedEntity;
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
@@ -91,9 +91,7 @@ public class ObjectionService implements IObjectionService {
                 .withStatus(objectionStatus)
                 .build();
 
-        Objection savedEntity = objectionRepository.save(entity);
-
-        return savedEntity;
+        return objectionRepository.save(entity);
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
@@ -21,7 +21,6 @@ import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.ObjectionStatus;
 import uk.gov.companieshouse.api.strikeoffobjections.model.patch.ObjectionPatch;
 import uk.gov.companieshouse.api.strikeoffobjections.model.patcher.ObjectionPatcher;
-import uk.gov.companieshouse.api.strikeoffobjections.model.response.ObjectionResponseDTO;
 import uk.gov.companieshouse.api.strikeoffobjections.processor.ObjectionProcessor;
 import uk.gov.companieshouse.api.strikeoffobjections.repository.ObjectionRepository;
 import uk.gov.companieshouse.api.strikeoffobjections.service.IObjectionService;
@@ -76,7 +75,6 @@ public class ObjectionService implements IObjectionService {
     public Objection createObjection(String requestId, String companyNumber, String ericUserId, String ericUserDetails) {
         Map<String, Object> logMap = buildLogMap(companyNumber, null, null);
         logger.infoContext(requestId, "Creating objection", logMap);
-        ObjectionResponseDTO response = new ObjectionResponseDTO();
 
         // TODO OBJ-231 process query result and return eligibility status
         ObjectionStatus objectionStatus = ObjectionStatus.OPEN;

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
@@ -21,6 +21,7 @@ import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.ObjectionStatus;
 import uk.gov.companieshouse.api.strikeoffobjections.model.patch.ObjectionPatch;
 import uk.gov.companieshouse.api.strikeoffobjections.model.patcher.ObjectionPatcher;
+import uk.gov.companieshouse.api.strikeoffobjections.model.response.ObjectionResponseDTO;
 import uk.gov.companieshouse.api.strikeoffobjections.processor.ObjectionProcessor;
 import uk.gov.companieshouse.api.strikeoffobjections.repository.ObjectionRepository;
 import uk.gov.companieshouse.api.strikeoffobjections.service.IObjectionService;
@@ -72,9 +73,13 @@ public class ObjectionService implements IObjectionService {
     }
 
     @Override
-    public String createObjection(String requestId, String companyNumber, String ericUserId, String ericUserDetails) {
+    public ObjectionResponseDTO createObjection(String requestId, String companyNumber, String ericUserId, String ericUserDetails) {
         Map<String, Object> logMap = buildLogMap(companyNumber, null, null);
         logger.infoContext(requestId, "Creating objection", logMap);
+        ObjectionResponseDTO response = new ObjectionResponseDTO();
+
+        // TODO OBJ-231 process query result and return eligibility status
+        ObjectionStatus obStat = ObjectionStatus.OPEN;
 
         final String userEmailAddress = ericHeaderParser.getEmailAddress(ericUserDetails);
 
@@ -83,11 +88,13 @@ public class ObjectionService implements IObjectionService {
                 .withCreatedOn(dateTimeSupplier.get())
                 .withCreatedBy(new CreatedBy(ericUserId, userEmailAddress))
                 .withHttpRequestId(requestId)
-                .withStatus(ObjectionStatus.OPEN)
+                .withStatus(obStat)
                 .build();
 
         Objection savedEntity = objectionRepository.save(entity);
-        return savedEntity.getId();
+        response.setId(savedEntity.getId());
+        response.setStatus(savedEntity.getStatus());
+        return response;
     }
 
     /**

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
@@ -88,7 +88,8 @@ class ObjectionControllerTest {
     @Test
     void createObjectionTest() {
         ObjectionResponseDTO objectionResponse = new ObjectionResponseDTO(OBJECTION_ID);
-        when(objectionService.createObjection(REQUEST_ID, COMPANY_NUMBER, AUTH_ID, AUTH_USER)).thenReturn(OBJECTION_ID);
+        ObjectionResponseDTO responseDTO = new ObjectionResponseDTO(OBJECTION_ID);
+        when(objectionService.createObjection(REQUEST_ID, COMPANY_NUMBER, AUTH_ID, AUTH_USER)).thenReturn(responseDTO);
         when(pluggableResponseEntityFactory.createResponse(any(ServiceResult.class))).thenReturn(
                 ResponseEntity.status(HttpStatus.CREATED).body(ChResponseBody.createNormalBody(objectionResponse)));
         ResponseEntity<ChResponseBody<ObjectionResponseDTO>> response = objectionController.createObjection(COMPANY_NUMBER, REQUEST_ID, AUTH_ID, AUTH_USER);
@@ -100,6 +101,20 @@ class ObjectionControllerTest {
 
         assertNotNull(responseBody.getSuccessBody());
         assertEquals(OBJECTION_ID, responseBody.getSuccessBody().getId());
+    }
+
+    @Test
+    void createObjectionEligibilityErrorTest() {
+        ObjectionResponseDTO objectionResponse = new ObjectionResponseDTO(OBJECTION_ID);
+        objectionResponse.setStatus(ObjectionStatus.INELIGIBLE_COMPANY_STRUCK_OFF);
+        when(objectionService.createObjection(REQUEST_ID, COMPANY_NUMBER, AUTH_ID, AUTH_USER)).thenReturn(objectionResponse);
+        ResponseEntity<ChResponseBody<ObjectionResponseDTO>> response = objectionController.createObjection(COMPANY_NUMBER, REQUEST_ID, AUTH_ID, AUTH_USER);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertNotNull(response.getBody());
+        ChResponseBody<ObjectionResponseDTO> responseBody = response.getBody();
+        assertNotNull(responseBody.getSuccessBody());
+        assertEquals(ObjectionStatus.INELIGIBLE_COMPANY_STRUCK_OFF, responseBody.getSuccessBody().getStatus());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
@@ -94,8 +94,7 @@ class ObjectionControllerTest {
 
         ObjectionResponseDTO objectionDTO = new ObjectionResponseDTO();
         objectionDTO.setId(OBJECTION_ID);
-        objectionDTO.setStatus(ObjectionStatus.SUBMITTED);
-        when(objectionMapper.objectionEntityToObjectionResponseDTO(objection)).thenReturn(objectionDTO);
+
         when(pluggableResponseEntityFactory.createResponse(any(ServiceResult.class))).thenReturn(
                 ResponseEntity.status(HttpStatus.CREATED).body(ChResponseBody.createNormalBody(objectionDTO)));
 
@@ -116,11 +115,6 @@ class ObjectionControllerTest {
         objection.setId(OBJECTION_ID);
         objection.setStatus(ObjectionStatus.INELIGIBLE_COMPANY_STRUCK_OFF);
         when(objectionService.createObjection(REQUEST_ID, COMPANY_NUMBER, AUTH_ID, AUTH_USER)).thenReturn(objection);
-
-        ObjectionResponseDTO objectionDTO = new ObjectionResponseDTO();
-        objectionDTO.setId(OBJECTION_ID);
-        objectionDTO.setStatus(ObjectionStatus.INELIGIBLE_COMPANY_STRUCK_OFF);
-        when(objectionMapper.objectionEntityToObjectionResponseDTO(objection)).thenReturn(objectionDTO);
 
         ResponseEntity<ChResponseBody<ObjectionResponseDTO>> response = objectionController.createObjection(COMPANY_NUMBER, REQUEST_ID, AUTH_ID, AUTH_USER);
 

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
@@ -87,11 +87,18 @@ class ObjectionControllerTest {
 
     @Test
     void createObjectionTest() {
-        ObjectionResponseDTO responseDTO = new ObjectionResponseDTO(OBJECTION_ID);
-        responseDTO.setStatus(ObjectionStatus.SUBMITTED);
-        when(objectionService.createObjection(REQUEST_ID, COMPANY_NUMBER, AUTH_ID, AUTH_USER)).thenReturn(responseDTO);
+        Objection objection = new Objection();
+        objection.setId(OBJECTION_ID);
+        objection.setStatus(ObjectionStatus.SUBMITTED);
+        when(objectionService.createObjection(REQUEST_ID, COMPANY_NUMBER, AUTH_ID, AUTH_USER)).thenReturn(objection);
+
+        ObjectionResponseDTO objectionDTO = new ObjectionResponseDTO();
+        objectionDTO.setId(OBJECTION_ID);
+        objectionDTO.setStatus(ObjectionStatus.SUBMITTED);
+        when(objectionMapper.objectionEntityToObjectionResponseDTO(objection)).thenReturn(objectionDTO);
         when(pluggableResponseEntityFactory.createResponse(any(ServiceResult.class))).thenReturn(
-                ResponseEntity.status(HttpStatus.CREATED).body(ChResponseBody.createNormalBody(responseDTO)));
+                ResponseEntity.status(HttpStatus.CREATED).body(ChResponseBody.createNormalBody(objectionDTO)));
+
         ResponseEntity<ChResponseBody<ObjectionResponseDTO>> response = objectionController.createObjection(COMPANY_NUMBER, REQUEST_ID, AUTH_ID, AUTH_USER);
 
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
@@ -105,9 +112,16 @@ class ObjectionControllerTest {
 
     @Test
     void createObjectionEligibilityErrorTest() {
-        ObjectionResponseDTO objectionResponse = new ObjectionResponseDTO(OBJECTION_ID);
-        objectionResponse.setStatus(ObjectionStatus.INELIGIBLE_COMPANY_STRUCK_OFF);
-        when(objectionService.createObjection(REQUEST_ID, COMPANY_NUMBER, AUTH_ID, AUTH_USER)).thenReturn(objectionResponse);
+        Objection objection = new Objection();
+        objection.setId(OBJECTION_ID);
+        objection.setStatus(ObjectionStatus.INELIGIBLE_COMPANY_STRUCK_OFF);
+        when(objectionService.createObjection(REQUEST_ID, COMPANY_NUMBER, AUTH_ID, AUTH_USER)).thenReturn(objection);
+
+        ObjectionResponseDTO objectionDTO = new ObjectionResponseDTO();
+        objectionDTO.setId(OBJECTION_ID);
+        objectionDTO.setStatus(ObjectionStatus.INELIGIBLE_COMPANY_STRUCK_OFF);
+        when(objectionMapper.objectionEntityToObjectionResponseDTO(objection)).thenReturn(objectionDTO);
+
         ResponseEntity<ChResponseBody<ObjectionResponseDTO>> response = objectionController.createObjection(COMPANY_NUMBER, REQUEST_ID, AUTH_ID, AUTH_USER);
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
@@ -87,11 +87,11 @@ class ObjectionControllerTest {
 
     @Test
     void createObjectionTest() {
-        ObjectionResponseDTO objectionResponse = new ObjectionResponseDTO(OBJECTION_ID);
         ObjectionResponseDTO responseDTO = new ObjectionResponseDTO(OBJECTION_ID);
+        responseDTO.setStatus(ObjectionStatus.SUBMITTED);
         when(objectionService.createObjection(REQUEST_ID, COMPANY_NUMBER, AUTH_ID, AUTH_USER)).thenReturn(responseDTO);
         when(pluggableResponseEntityFactory.createResponse(any(ServiceResult.class))).thenReturn(
-                ResponseEntity.status(HttpStatus.CREATED).body(ChResponseBody.createNormalBody(objectionResponse)));
+                ResponseEntity.status(HttpStatus.CREATED).body(ChResponseBody.createNormalBody(responseDTO)));
         ResponseEntity<ChResponseBody<ObjectionResponseDTO>> response = objectionController.createObjection(COMPANY_NUMBER, REQUEST_ID, AUTH_ID, AUTH_USER);
 
         assertEquals(HttpStatus.CREATED, response.getStatusCode());

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/entity/ObjectionStatusTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/entity/ObjectionStatusTest.java
@@ -1,0 +1,27 @@
+package uk.gov.companieshouse.api.strikeoffobjections.model.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ObjectionStatusTest {
+
+    @Test
+    public void testWhenEligible() {
+        ObjectionStatus objectionStatus = ObjectionStatus.OPEN;
+        assertFalse(objectionStatus.isIneligibleStatus());
+    }
+
+    @Test
+    public void testWhenIneligibleStruckOff() {
+        ObjectionStatus objectionStatus = ObjectionStatus.INELIGIBLE_COMPANY_STRUCK_OFF;
+        assertTrue(objectionStatus.isIneligibleStatus());
+    }
+
+    @Test
+    public void testWhenIneligibleNoDissolutionAction() {
+        ObjectionStatus objectionStatus = ObjectionStatus.INELIGIBLE_NO_DISSOLUTION_ACTION;
+        assertTrue(objectionStatus.isIneligibleStatus());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/entity/ObjectionStatusTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/entity/ObjectionStatusTest.java
@@ -10,18 +10,18 @@ public class ObjectionStatusTest {
     @Test
     public void testWhenEligible() {
         ObjectionStatus objectionStatus = ObjectionStatus.OPEN;
-        assertFalse(objectionStatus.isIneligibleStatus());
+        assertFalse(objectionStatus.isIneligible());
     }
 
     @Test
     public void testWhenIneligibleStruckOff() {
         ObjectionStatus objectionStatus = ObjectionStatus.INELIGIBLE_COMPANY_STRUCK_OFF;
-        assertTrue(objectionStatus.isIneligibleStatus());
+        assertTrue(objectionStatus.isIneligible());
     }
 
     @Test
     public void testWhenIneligibleNoDissolutionAction() {
         ObjectionStatus objectionStatus = ObjectionStatus.INELIGIBLE_NO_DISSOLUTION_ACTION;
-        assertTrue(objectionStatus.isIneligibleStatus());
+        assertTrue(objectionStatus.isIneligible());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
@@ -24,6 +24,7 @@ import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.ObjectionStatus;
 import uk.gov.companieshouse.api.strikeoffobjections.model.patcher.ObjectionPatcher;
 import uk.gov.companieshouse.api.strikeoffobjections.model.patch.ObjectionPatch;
+import uk.gov.companieshouse.api.strikeoffobjections.model.response.ObjectionResponseDTO;
 import uk.gov.companieshouse.api.strikeoffobjections.processor.ObjectionProcessor;
 import uk.gov.companieshouse.api.strikeoffobjections.repository.ObjectionRepository;
 import uk.gov.companieshouse.api.strikeoffobjections.utils.Utils;
@@ -105,10 +106,10 @@ class ObjectionServiceTest {
         when(ericHeaderParser.getEmailAddress(AUTH_USER)).thenReturn(E_MAIL);
 
         ArgumentCaptor<Objection> acObjection = ArgumentCaptor.forClass(Objection.class);
-        String returnedId = objectionService.createObjection(REQUEST_ID, COMPANY_NUMBER, AUTH_ID, AUTH_USER);
+        ObjectionResponseDTO responseDTO = objectionService.createObjection(REQUEST_ID, COMPANY_NUMBER, AUTH_ID, AUTH_USER);
 
         verify(objectionRepository).save(acObjection.capture());
-        assertEquals(OBJECTION_ID, returnedId);
+        assertEquals(OBJECTION_ID, responseDTO.getId());
         assertEquals(MOCKED_TIME_STAMP, acObjection.getValue().getCreatedOn());
         assertEquals(COMPANY_NUMBER, acObjection.getValue().getCompanyNumber());
         assertEquals(ObjectionStatus.OPEN, acObjection.getValue().getStatus());

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.api.strikeoffobjections.service.impl;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -20,11 +19,11 @@ import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClientR
 import uk.gov.companieshouse.api.strikeoffobjections.file.ObjectionsLinkKeys;
 import uk.gov.companieshouse.api.strikeoffobjections.groups.Unit;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
+import uk.gov.companieshouse.api.strikeoffobjections.model.entity.CreatedBy;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.ObjectionStatus;
 import uk.gov.companieshouse.api.strikeoffobjections.model.patcher.ObjectionPatcher;
 import uk.gov.companieshouse.api.strikeoffobjections.model.patch.ObjectionPatch;
-import uk.gov.companieshouse.api.strikeoffobjections.model.response.ObjectionResponseDTO;
 import uk.gov.companieshouse.api.strikeoffobjections.processor.ObjectionProcessor;
 import uk.gov.companieshouse.api.strikeoffobjections.repository.ObjectionRepository;
 import uk.gov.companieshouse.api.strikeoffobjections.utils.Utils;
@@ -32,7 +31,6 @@ import uk.gov.companieshouse.service.ServiceException;
 import uk.gov.companieshouse.service.ServiceResult;
 
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -101,20 +99,24 @@ class ObjectionServiceTest {
                 .withCompanyNumber(COMPANY_NUMBER)
                 .build();
         returnedEntity.setId(OBJECTION_ID);
+        returnedEntity.setCreatedOn(MOCKED_TIME_STAMP);
+        returnedEntity.setStatus(ObjectionStatus.OPEN);
+        CreatedBy createdBy = new CreatedBy(AUTH_ID, E_MAIL);
+        returnedEntity.setCreatedBy(createdBy);
+
         when(objectionRepository.save(any())).thenReturn(returnedEntity);
         when(localDateTimeSupplier.get()).thenReturn(MOCKED_TIME_STAMP);
         when(ericHeaderParser.getEmailAddress(AUTH_USER)).thenReturn(E_MAIL);
 
-        ArgumentCaptor<Objection> acObjection = ArgumentCaptor.forClass(Objection.class);
-        ObjectionResponseDTO responseDTO = objectionService.createObjection(REQUEST_ID, COMPANY_NUMBER, AUTH_ID, AUTH_USER);
+        Objection objectionResponse = objectionService.createObjection(REQUEST_ID, COMPANY_NUMBER, AUTH_ID, AUTH_USER);
 
-        verify(objectionRepository).save(acObjection.capture());
-        assertEquals(OBJECTION_ID, responseDTO.getId());
-        assertEquals(MOCKED_TIME_STAMP, acObjection.getValue().getCreatedOn());
-        assertEquals(COMPANY_NUMBER, acObjection.getValue().getCompanyNumber());
-        assertEquals(ObjectionStatus.OPEN, acObjection.getValue().getStatus());
-        assertEquals(AUTH_ID, acObjection.getValue().getCreatedBy().getId());
-        assertEquals(E_MAIL, acObjection.getValue().getCreatedBy().getEmail());
+        verify(objectionRepository).save(any());
+        assertEquals(OBJECTION_ID, objectionResponse.getId());
+        assertEquals(MOCKED_TIME_STAMP, objectionResponse.getCreatedOn());
+        assertEquals(COMPANY_NUMBER, objectionResponse.getCompanyNumber());
+        assertEquals(ObjectionStatus.OPEN, objectionResponse.getStatus());
+        assertEquals(AUTH_ID, objectionResponse.getCreatedBy().getId());
+        assertEquals(E_MAIL, objectionResponse.getCreatedBy().getEmail());
     }
 
     @Test
@@ -609,7 +611,7 @@ class ObjectionServiceTest {
     }
 
     @Test
-    public void willCallFileTransferApiForDownload() throws ServiceException {
+    void willCallFileTransferApiForDownload() throws ServiceException {
         HttpServletResponse httpServletResponse = new MockHttpServletResponse();
         FileTransferApiClientResponse dummyDownloadResponse = Utils.dummyDownloadResponse();
 


### PR DESCRIPTION
Updated service call to return a DTO rather than a string which contains a status as well as an id.

The controller will return an hhtp 400 error and a body ctaining a dto with the objection status in it.
For the response have used a normal body rather than an error body as this takes an error container object and will mean alterations to the agreed schema.
