### PR TITLE
OBJ-231 Integrate action code validation into create objection

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/common/LogConstants.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/common/LogConstants.java
@@ -2,9 +2,11 @@ package uk.gov.companieshouse.api.strikeoffobjections.common;
 
 public enum LogConstants {
 
+    ACTION_CODE("action_code"),
+    ATTACHMENT_ID("attachment_id"),
     COMPANY_NUMBER("company_number"),
     OBJECTION_ID("objection_id"),
-    ATTACHMENT_ID("attachment_id");
+    OBJECTION_STATUS("objection_status");
 
     private String value;
 

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/entity/Objection.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/entity/Objection.java
@@ -19,7 +19,7 @@ public class Objection {
         private String companyNumber;
         private String reason;
         private ObjectionStatus status;
-        private int actionCode;
+        private Long actionCode;
         private String httpRequestId;
 
         public Builder withCreatedOn(LocalDateTime createdOn) {
@@ -48,7 +48,7 @@ public class Objection {
             return this;
         }
 
-        public Builder withActionCode(int actionCode) {
+        public Builder withActionCode(Long actionCode) {
             this.actionCode = actionCode;
             return this;
         }
@@ -86,7 +86,7 @@ public class Objection {
     @Field("status")
     private ObjectionStatus status;
     @Field("action_code")
-    private int actionCode;
+    private Long actionCode;
     @Field("http_request_id")
     @JsonIgnore
     private String httpRequestId;
@@ -153,11 +153,11 @@ public class Objection {
         this.status = status;
     }
 
-    public int getActionCode() {
+    public Long getActionCode() {
         return actionCode;
     }
 
-    public void setActionCode(int actionCode) {
+    public void setActionCode(Long actionCode) {
         this.actionCode = actionCode;
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
@@ -50,36 +50,32 @@ public class ObjectionService implements IObjectionService {
     private static final String ATTACHMENT_NOT_DELETED_SHORT = "Unable to delete attachment %s";
     private static final String INVALID_PATCH_STATUS = "Unable to patch status to %s for Objection id: %s";
 
+    @Autowired
     private ObjectionRepository objectionRepository;
-    private ApiLogger logger;
-    private Supplier<LocalDateTime> dateTimeSupplier;
-    private ObjectionPatcher objectionPatcher;
-    private FileTransferApiClient fileTransferApiClient;
-    private ERICHeaderParser ericHeaderParser;
-    private ObjectionProcessor objectionProcessor;
-    private OracleQueryClient oracleQueryClient;
-    private ActionCodeValidator actionCodeValidator;
 
     @Autowired
-    public ObjectionService(ObjectionRepository objectionRepository,
-                            ApiLogger logger,
-                            Supplier<LocalDateTime> dateTimeSupplier,
-                            ObjectionPatcher objectionPatcher,
-                            FileTransferApiClient fileTransferApiClient,
-                            ERICHeaderParser ericHeaderParser,
-                            ObjectionProcessor objectionProcessor,
-                            OracleQueryClient oracleQueryClient,
-                            ActionCodeValidator actionCodeValidator) {
-        this.objectionRepository = objectionRepository;
-        this.logger = logger;
-        this.dateTimeSupplier = dateTimeSupplier;
-        this.objectionPatcher = objectionPatcher;
-        this.fileTransferApiClient = fileTransferApiClient;
-        this.ericHeaderParser = ericHeaderParser;
-        this.objectionProcessor = objectionProcessor;
-        this.oracleQueryClient = oracleQueryClient;
-        this.actionCodeValidator = actionCodeValidator;
-    }
+    private ApiLogger logger;
+
+    @Autowired
+    private Supplier<LocalDateTime> dateTimeSupplier;
+
+    @Autowired
+    private ObjectionPatcher objectionPatcher;
+
+    @Autowired
+    private FileTransferApiClient fileTransferApiClient;
+
+    @Autowired
+    private ERICHeaderParser ericHeaderParser;
+
+    @Autowired
+    private ObjectionProcessor objectionProcessor;
+
+    @Autowired
+    private OracleQueryClient oracleQueryClient;
+
+    @Autowired
+    private ActionCodeValidator actionCodeValidator;
 
     @Override
     public Objection createObjection(String requestId, String companyNumber, String ericUserId, String ericUserDetails) {
@@ -88,7 +84,7 @@ public class ObjectionService implements IObjectionService {
 
         final Long actionCode = getActionCode(companyNumber, requestId);
 
-        final ObjectionStatus objectionStatus = getObjectionStatus(actionCode, companyNumber, requestId);
+        final ObjectionStatus objectionStatus = getObjectionStatusForCreate(actionCode, companyNumber, requestId);
 
         final String userEmailAddress = ericHeaderParser.getEmailAddress(ericUserDetails);
 
@@ -105,14 +101,14 @@ public class ObjectionService implements IObjectionService {
     }
 
     private Long getActionCode(String companyNumber, String requestId) {
-        long actionCode = oracleQueryClient.getCompanyActionCode(companyNumber);
+        Long actionCode = oracleQueryClient.getCompanyActionCode(companyNumber);
 
         logger.debugContext(requestId, "Company action code is " + actionCode);
 
         return actionCode;
     }
 
-    private ObjectionStatus getObjectionStatus(Long actionCode, String companyNumber, String logContext) {
+    private ObjectionStatus getObjectionStatusForCreate(Long actionCode, String companyNumber, String logContext) {
         ObjectionStatus objectionStatus = ObjectionStatus.OPEN;
         try {
             actionCodeValidator.validate(actionCode, logContext);

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
@@ -26,6 +26,8 @@ import uk.gov.companieshouse.api.strikeoffobjections.model.patcher.ObjectionPatc
 import uk.gov.companieshouse.api.strikeoffobjections.processor.ObjectionProcessor;
 import uk.gov.companieshouse.api.strikeoffobjections.repository.ObjectionRepository;
 import uk.gov.companieshouse.api.strikeoffobjections.service.IObjectionService;
+import uk.gov.companieshouse.api.strikeoffobjections.validation.ActionCodeValidator;
+import uk.gov.companieshouse.api.strikeoffobjections.validation.ValidationException;
 import uk.gov.companieshouse.service.ServiceException;
 import uk.gov.companieshouse.service.ServiceResult;
 import uk.gov.companieshouse.service.links.Links;
@@ -56,6 +58,7 @@ public class ObjectionService implements IObjectionService {
     private ERICHeaderParser ericHeaderParser;
     private ObjectionProcessor objectionProcessor;
     private OracleQueryClient oracleQueryClient;
+    private ActionCodeValidator actionCodeValidator;
 
     @Autowired
     public ObjectionService(ObjectionRepository objectionRepository,
@@ -65,7 +68,8 @@ public class ObjectionService implements IObjectionService {
                             FileTransferApiClient fileTransferApiClient,
                             ERICHeaderParser ericHeaderParser,
                             ObjectionProcessor objectionProcessor,
-                            OracleQueryClient oracleQueryClient) {
+                            OracleQueryClient oracleQueryClient,
+                            ActionCodeValidator actionCodeValidator) {
         this.objectionRepository = objectionRepository;
         this.logger = logger;
         this.dateTimeSupplier = dateTimeSupplier;
@@ -74,6 +78,7 @@ public class ObjectionService implements IObjectionService {
         this.ericHeaderParser = ericHeaderParser;
         this.objectionProcessor = objectionProcessor;
         this.oracleQueryClient = oracleQueryClient;
+        this.actionCodeValidator = actionCodeValidator;
     }
 
     @Override
@@ -81,11 +86,9 @@ public class ObjectionService implements IObjectionService {
         Map<String, Object> logMap = buildLogMap(companyNumber, null, null);
         logger.infoContext(requestId, "Creating objection", logMap);
 
-        @SuppressWarnings("unused")
-        long actionCode = getActionCode(companyNumber, requestId);
+        final Long actionCode = getActionCode(companyNumber, requestId);
 
-        // TODO OBJ-231 check action code and set eligibility status
-        ObjectionStatus objectionStatus = ObjectionStatus.OPEN;
+        final ObjectionStatus objectionStatus = getObjectionStatus(actionCode, companyNumber, requestId);
 
         final String userEmailAddress = ericHeaderParser.getEmailAddress(ericUserDetails);
 
@@ -94,10 +97,34 @@ public class ObjectionService implements IObjectionService {
                 .withCreatedOn(dateTimeSupplier.get())
                 .withCreatedBy(new CreatedBy(ericUserId, userEmailAddress))
                 .withHttpRequestId(requestId)
+                .withActionCode(actionCode)
                 .withStatus(objectionStatus)
                 .build();
 
         return objectionRepository.save(entity);
+    }
+
+    private Long getActionCode(String companyNumber, String requestId) {
+        long actionCode = oracleQueryClient.getCompanyActionCode(companyNumber);
+
+        logger.debugContext(requestId, "Company action code is " + actionCode);
+
+        return actionCode;
+    }
+
+    private ObjectionStatus getObjectionStatus(Long actionCode, String companyNumber, String logContext) {
+        ObjectionStatus objectionStatus = ObjectionStatus.OPEN;
+        try {
+            actionCodeValidator.validate(actionCode, logContext);
+        } catch (ValidationException validationException) {
+            objectionStatus = validationException.getStatus();
+
+            Map<String, Object> logMap = buildLogMap(companyNumber, null, null);
+            logMap.put(LogConstants.ACTION_CODE.getValue(), actionCode);
+            logMap.put(LogConstants.OBJECTION_STATUS.getValue(), objectionStatus);
+            logger.infoContext(logContext, "Action Code validation failed", logMap);
+        }
+        return objectionStatus;
     }
 
     /**
@@ -317,13 +344,5 @@ public class ObjectionService implements IObjectionService {
             logMap.put(LogConstants.ATTACHMENT_ID.getValue(), attachmentId);
         }
         return logMap;
-    }
-
-    private long getActionCode(String companyNumber, String requestId) {
-        long actionCode = oracleQueryClient.getCompanyActionCode(companyNumber);
-
-        logger.debugContext(requestId, "Company action code is " + actionCode);
- 
-        return actionCode;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/validation/AllowedValuesValidationRule.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/validation/AllowedValuesValidationRule.java
@@ -22,7 +22,7 @@ public class AllowedValuesValidationRule<T> implements ValidationRule<T> {
     @Override
     public void validate(T input, String logContext) throws ValidationException {
         if (!allowableValues.contains(input)) {
-            apiLogger.debugContext(logContext, String.format("%s is not an allowed value", input));
+            apiLogger.debugContext(logContext, String.format("AllowedValuesValidationRule %s is not an allowed value", input));
             throw new ValidationException(failureStatus);
         }
     }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/validation/AllowedValuesValidationRule.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/validation/AllowedValuesValidationRule.java
@@ -22,7 +22,7 @@ public class AllowedValuesValidationRule<T> implements ValidationRule<T> {
     @Override
     public void validate(T input, String logContext) throws ValidationException {
         if (!allowableValues.contains(input)) {
-            apiLogger.debugContext(logContext, String.format("AllowedValuesValidationRule %s is not an allowed value", input));
+            apiLogger.debugContext(logContext, String.format("%s %s is not an allowed value", this.getClass().getSimpleName(), input));
             throw new ValidationException(failureStatus);
         }
     }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/validation/DisallowedValuesValidationRule.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/validation/DisallowedValuesValidationRule.java
@@ -22,7 +22,7 @@ public class DisallowedValuesValidationRule<T> implements ValidationRule<T> {
     @Override
     public void validate(T input, String logContext) throws ValidationException {
         if (disallowedValues.contains(input)) {
-            apiLogger.debugContext(logContext, String.format("DisallowedValuesValidationRule %s is a disallowed value", input));
+            apiLogger.debugContext(logContext, String.format("%s %s is a disallowed value", this.getClass().getSimpleName(), input));
             throw new ValidationException(failureStatus);
         }
     }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/validation/DisallowedValuesValidationRule.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/validation/DisallowedValuesValidationRule.java
@@ -22,7 +22,7 @@ public class DisallowedValuesValidationRule<T> implements ValidationRule<T> {
     @Override
     public void validate(T input, String logContext) throws ValidationException {
         if (disallowedValues.contains(input)) {
-            apiLogger.debugContext(logContext, String.format("%s is a disallowed value", input));
+            apiLogger.debugContext(logContext, String.format("DisallowedValuesValidationRule %s is a disallowed value", input));
             throw new ValidationException(failureStatus);
         }
     }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/entity/ObjectionTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/entity/ObjectionTest.java
@@ -42,7 +42,7 @@ public class ObjectionTest {
                        .withCompanyNumber("00006400")
                        .withReason("This is a test")
                        .withStatus(ObjectionStatus.OPEN)
-                       .withActionCode(4400)
+                       .withActionCode(4400L)
                        .build();
 
        objection.addAttachment(attachment);
@@ -61,6 +61,6 @@ public class ObjectionTest {
 
        assertEquals("This is a test", objection.getReason());
        assertEquals(ObjectionStatus.OPEN, objection.getStatus());
-       assertEquals(4400, objection.getActionCode());
+       assertEquals(4400L, objection.getActionCode());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/validation/AllowedValuesValidationRuleTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/validation/AllowedValuesValidationRuleTest.java
@@ -50,4 +50,13 @@ class AllowedValuesValidationRuleTest {
 
         assertEquals(FAILURE_STATUS, ve.getStatus());
     }
+
+    @Test
+    void validateThrowsExceptionWhenNullIsInputTest() {
+        ValidationException ve = assertThrows(
+                ValidationException.class,
+                () -> allowedValuesValidationRule.validate(null, LOG_CONTEXT));
+
+        assertEquals(FAILURE_STATUS, ve.getStatus());
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/validation/DisallowedValuesValidationRuleTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/validation/DisallowedValuesValidationRuleTest.java
@@ -43,6 +43,11 @@ class DisallowedValuesValidationRuleTest {
     }
 
     @Test
+    void validateIsOkWhenNullIsInputTest() throws ValidationException {
+        disallowedValuesValidationRule.validate(null, LOG_CONTEXT);
+    }
+
+    @Test
     void validateThrowsExceptionTest() {
         ValidationException ve = assertThrows(
                 ValidationException.class,


### PR DESCRIPTION
Plugging in the actionCodeValidator into ObjectionService so we can validate the action code when creating a new Objection

Also, the ObjectionService constructor args list had grown too large (Sonar) so had to move them out into fields.