### PR TITLE
OBJ-263 change can to is

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/entity/CreatedBy.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/entity/CreatedBy.java
@@ -35,7 +35,7 @@ public class CreatedBy {
         return fullName;
     }
 
-    public boolean canShareIdentity() {
+    public boolean isShareIdentity() {
         return shareIdentity;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/EmailService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/EmailService.java
@@ -134,7 +134,7 @@ public class EmailService implements IEmailService {
         data.put("objection_id", objection.getId());
         data.put("to", email);
         data.put("full_name", objection.getCreatedBy().getFullName());
-        data.put("share_identity", objection.getCreatedBy().canShareIdentity());
+        data.put("share_identity", objection.getCreatedBy().isShareIdentity());
         data.put("company_name", companyName);
         data.put("company_number", objection.getCompanyNumber());
         data.put("reason", objection.getReason());


### PR DESCRIPTION
Jackson uses getters to serialize objects, canShareIdentity is not standard so Jackson didn't know it could use it to serialize the shareIdentity field.