### PR TITLE
Feature/obj 297 user details in patch

### DIFF
--- a/spec/schema.json
+++ b/spec/schema.json
@@ -421,6 +421,12 @@
     "Patch": {
       "type": "object",
       "properties": {
+        "fullName": {
+          "type": "string"
+        },
+        "shareIdentity": {
+          "type": "boolean"
+        },
         "reason": {
           "type": "string"
         },

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/entity/CreatedBy.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/entity/CreatedBy.java
@@ -35,7 +35,15 @@ public class CreatedBy {
         return fullName;
     }
 
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
+
     public boolean isShareIdentity() {
         return shareIdentity;
+    }
+
+    public void setShareIdentity(boolean shareIdentity) {
+        this.shareIdentity = shareIdentity;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/patch/ObjectionPatch.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/patch/ObjectionPatch.java
@@ -3,8 +3,26 @@ package uk.gov.companieshouse.api.strikeoffobjections.model.patch;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.ObjectionStatus;
 
 public class ObjectionPatch {
+    private String fullName;
+    private Boolean shareIdentity;
     private String reason;
     private ObjectionStatus status;
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
+
+    public Boolean isShareIdentity() {
+        return shareIdentity;
+    }
+
+    public void setShareIdentity(Boolean shareIdentity) {
+        this.shareIdentity = shareIdentity;
+    }
 
     public String getReason() {
         return reason;

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/patcher/ObjectionPatcher.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/patcher/ObjectionPatcher.java
@@ -20,6 +20,14 @@ public class ObjectionPatcher {
 
     public Objection patchObjection(ObjectionPatch objectionPatch, String requestId, Objection existingObjection) {
         existingObjection.setHttpRequestId(requestId);
+        if (objectionPatch.getFullName() != null) {
+            existingObjection.getCreatedBy().setFullName(objectionPatch.getFullName());
+        }
+
+        if (objectionPatch.isShareIdentity() != null) {
+            existingObjection.getCreatedBy().setShareIdentity(objectionPatch.isShareIdentity());
+        }
+
         if (objectionPatch.getReason() != null) {
             existingObjection.setReason(objectionPatch.getReason());
         }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/patcher/ObjectionPatcherTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/patcher/ObjectionPatcherTest.java
@@ -7,6 +7,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.strikeoffobjections.groups.Unit;
+import uk.gov.companieshouse.api.strikeoffobjections.model.entity.CreatedBy;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.ObjectionStatus;
 import uk.gov.companieshouse.api.strikeoffobjections.model.patch.ObjectionPatch;
@@ -25,6 +26,7 @@ class ObjectionPatcherTest {
     private static final String OBJECTION_ID = "OBJECTION_ID";
     private static final String COMPANY_NUMBER = "COMPANY_NUMBER";
     private static final String REQUEST_ID = "REQUEST_ID";
+    private static final String FULL_NAME = "Joe Bloggs";
     private static final LocalDateTime CREATED_ON = LocalDateTime.of(2020, 1, 1, 1, 1);
     private static final LocalDateTime STATUS_CHANGED_ON = LocalDateTime.of(2021, 1, 1, 1, 1);
 
@@ -37,12 +39,16 @@ class ObjectionPatcherTest {
     @Test
     void requestToObjectionCreationTest() {
         ObjectionPatch objectionPatch = new ObjectionPatch();
+        objectionPatch.setFullName(FULL_NAME);
+        objectionPatch.setShareIdentity(Boolean.TRUE);
         objectionPatch.setReason(REASON);
         objectionPatch.setStatus(ObjectionStatus.OPEN);
 
+        CreatedBy createdBy = new CreatedBy( "", "","Not Joe Bloggs", Boolean.FALSE);
         Objection existingObjection = new Objection();
         existingObjection.setCreatedOn(CREATED_ON);
         existingObjection.setId(OBJECTION_ID);
+        existingObjection.setCreatedBy(createdBy);
         existingObjection.setCompanyNumber(COMPANY_NUMBER);
 
         when(dateTimeSupplier.get()).thenReturn(STATUS_CHANGED_ON);
@@ -51,6 +57,8 @@ class ObjectionPatcherTest {
         assertEquals(REASON, objection.getReason());
         assertEquals(OBJECTION_ID, objection.getId());
         assertEquals(COMPANY_NUMBER, objection.getCompanyNumber());
+        assertEquals(FULL_NAME, objection.getCreatedBy().getFullName());
+        assertEquals(Boolean.TRUE, objection.getCreatedBy().isShareIdentity());
         assertEquals(ObjectionStatus.OPEN, objection.getStatus());
         assertEquals(REQUEST_ID, objection.getHttpRequestId());
         assertEquals(CREATED_ON, objection.getCreatedOn());

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/patcher/ObjectionPatcherTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/patcher/ObjectionPatcherTest.java
@@ -64,4 +64,33 @@ class ObjectionPatcherTest {
         assertEquals(CREATED_ON, objection.getCreatedOn());
         assertEquals(STATUS_CHANGED_ON, objection.getStatusChangedOn());
     }
+
+    @Test
+    void testShareIdNotChangedWhenNullInPatch() {
+        ObjectionPatch objectionPatch = new ObjectionPatch();
+        objectionPatch.setFullName(FULL_NAME);
+        objectionPatch.setShareIdentity(null);
+        objectionPatch.setReason(REASON);
+        objectionPatch.setStatus(ObjectionStatus.OPEN);
+
+        CreatedBy createdBy = new CreatedBy( "", "","Not Joe Bloggs", Boolean.TRUE);
+        Objection existingObjection = new Objection();
+        existingObjection.setCreatedOn(CREATED_ON);
+        existingObjection.setId(OBJECTION_ID);
+        existingObjection.setCreatedBy(createdBy);
+        existingObjection.setCompanyNumber(COMPANY_NUMBER);
+
+        when(dateTimeSupplier.get()).thenReturn(STATUS_CHANGED_ON);
+        Objection objection = objectionPatcher.patchObjection(objectionPatch, REQUEST_ID, existingObjection);
+
+        assertEquals(REASON, objection.getReason());
+        assertEquals(OBJECTION_ID, objection.getId());
+        assertEquals(COMPANY_NUMBER, objection.getCompanyNumber());
+        assertEquals(FULL_NAME, objection.getCreatedBy().getFullName());
+        assertEquals(Boolean.TRUE, objection.getCreatedBy().isShareIdentity());
+        assertEquals(ObjectionStatus.OPEN, objection.getStatus());
+        assertEquals(REQUEST_ID, objection.getHttpRequestId());
+        assertEquals(CREATED_ON, objection.getCreatedOn());
+        assertEquals(STATUS_CHANGED_ON, objection.getStatusChangedOn());
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
@@ -186,6 +186,8 @@ class ObjectionServiceTest {
         Objection objection = new Objection();
         objection.setId(OBJECTION_ID);
         ObjectionPatch objectionPatch = new ObjectionPatch();
+        objectionPatch.setFullName(FULL_NAME);
+        objectionPatch.setShareIdentity(Boolean.TRUE);
         objectionPatch.setReason(REASON);
         objectionPatch.setStatus(ObjectionStatus.PROCESSED);
         when(objectionRepository.findById(any())).thenReturn(Optional.of(existingObjection));
@@ -219,6 +221,8 @@ class ObjectionServiceTest {
         objection.setId(OBJECTION_ID);
 
         ObjectionPatch objectionPatch = new ObjectionPatch();
+        objectionPatch.setFullName(FULL_NAME);
+        objectionPatch.setShareIdentity(Boolean.TRUE);
         objectionPatch.setReason(REASON);
         objectionPatch.setStatus(ObjectionStatus.SUBMITTED);
 
@@ -241,6 +245,8 @@ class ObjectionServiceTest {
         objection.setId(OBJECTION_ID);
 
         ObjectionPatch objectionPatch = new ObjectionPatch();
+        objectionPatch.setFullName(FULL_NAME);
+        objectionPatch.setShareIdentity(Boolean.TRUE);
         objectionPatch.setReason(REASON);
         objectionPatch.setStatus(ObjectionStatus.SUBMITTED);
 


### PR DESCRIPTION
API changes relating to OBJ-284 so that when "change" is selected for user details and continue is pressed the details are sent to the api which needs to pick them up and process them along with any other changed data.