### PR TITLE
OBJ-299 annotations to receiver name format correction in the web

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/CreatedByMapper.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/CreatedByMapper.java
@@ -1,0 +1,13 @@
+package uk.gov.companieshouse.api.strikeoffobjections.controller;
+
+import org.mapstruct.Mapper;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.strikeoffobjections.model.entity.CreatedBy;
+import uk.gov.companieshouse.api.strikeoffobjections.model.response.CreatedByResponseDTO;
+
+@Component
+@Mapper(componentModel = "spring")
+public interface CreatedByMapper {
+
+    CreatedByResponseDTO createdByEntityToCreatedByResponseDTO(CreatedBy createdBy);
+}

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/create/ObjectionCreate.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/create/ObjectionCreate.java
@@ -1,8 +1,11 @@
 package uk.gov.companieshouse.api.strikeoffobjections.model.create;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ObjectionCreate {
 
+    @JsonProperty("full_name")
     private String fullName;
+    @JsonProperty("share_identity")
     private boolean shareIdentity;
 
     public String getFullName() {

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/patch/ObjectionPatch.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/patch/ObjectionPatch.java
@@ -1,9 +1,13 @@
 package uk.gov.companieshouse.api.strikeoffobjections.model.patch;
 
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.ObjectionStatus;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ObjectionPatch {
+
+    @JsonProperty("full_name")
     private String fullName;
+    @JsonProperty("share_identity")
     private Boolean shareIdentity;
     private String reason;
     private ObjectionStatus status;

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/response/CreatedByResponseDTO.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/response/CreatedByResponseDTO.java
@@ -1,0 +1,56 @@
+package uk.gov.companieshouse.api.strikeoffobjections.model.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CreatedByResponseDTO {
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("email")
+    private String email;
+
+    @JsonProperty("full_name")
+    private String fullName;
+
+    @JsonProperty("share_identity")
+    private boolean shareIdentity;
+
+    public CreatedByResponseDTO() {
+
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
+
+    public boolean isShareIdentity() {
+        return shareIdentity;
+    }
+
+    public void setShareIdentity(boolean shareIdentity) {
+        this.shareIdentity = shareIdentity;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/response/CreatedByResponseDTO.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/response/CreatedByResponseDTO.java
@@ -18,10 +18,6 @@ public class CreatedByResponseDTO {
     @JsonProperty("share_identity")
     private boolean shareIdentity;
 
-    public CreatedByResponseDTO() {
-
-    }
-
     public String getId() {
         return id;
     }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/response/ObjectionResponseDTO.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/response/ObjectionResponseDTO.java
@@ -17,7 +17,7 @@ public class ObjectionResponseDTO {
     private String createdOn;
 
     @JsonProperty("created_by")
-    private CreatedBy createdBy;
+    private CreatedByResponseDTO createdBy;
 
     @JsonProperty("company_number")
     private String companyNumber;
@@ -54,11 +54,11 @@ public class ObjectionResponseDTO {
         this.createdOn = createdOn;
     }
 
-    public CreatedBy getCreatedBy() {
+    public CreatedByResponseDTO getCreatedBy() {
         return createdBy;
     }
 
-    public void setCreatedBy(CreatedBy createdBy) {
+    public void setCreatedBy(CreatedByResponseDTO createdBy) {
         this.createdBy = createdBy;
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/response/ObjectionResponseDTO.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/response/ObjectionResponseDTO.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.api.strikeoffobjections.model.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import uk.gov.companieshouse.api.strikeoffobjections.model.entity.CreatedBy;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.ObjectionStatus;
 
 import java.util.List;

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
@@ -21,10 +21,12 @@ import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClientR
 import uk.gov.companieshouse.api.strikeoffobjections.groups.Unit;
 import uk.gov.companieshouse.api.strikeoffobjections.model.create.ObjectionCreate;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
+import uk.gov.companieshouse.api.strikeoffobjections.model.entity.CreatedBy;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.ObjectionStatus;
 import uk.gov.companieshouse.api.strikeoffobjections.model.patch.ObjectionPatch;
 import uk.gov.companieshouse.api.strikeoffobjections.model.response.AttachmentResponseDTO;
+import uk.gov.companieshouse.api.strikeoffobjections.model.response.CreatedByResponseDTO;
 import uk.gov.companieshouse.api.strikeoffobjections.model.response.ObjectionResponseDTO;
 import uk.gov.companieshouse.api.strikeoffobjections.service.IObjectionService;
 import uk.gov.companieshouse.api.strikeoffobjections.utils.Utils;
@@ -47,7 +49,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -289,7 +290,7 @@ class ObjectionControllerTest {
     }
 
     @Test
-    void testMapper() {
+    void testAttachmentMapper() {
         //given
         Attachment attachment = new Attachment();
         attachment.setId("123-456");
@@ -312,6 +313,23 @@ class ObjectionControllerTest {
         assertEquals("TEXT", attachmentDTO.getContentType());
         assertEquals(5, attachmentDTO.getSize());
         assertEquals("link to SELF", attachmentDTO.getLinks().getLink(CoreLinkKeys.SELF));
+    }
+
+    @Test
+    void testCreatedByMapper() {
+        //given
+        CreatedBy createdBy = new CreatedBy("abc-123", "jb@ch.gov.uk", "Joe Bloggs", true);
+
+        //when
+        CreatedByMapper mapper = Mappers.getMapper(CreatedByMapper.class);
+        CreatedByResponseDTO createdByResponseDTO = mapper.createdByEntityToCreatedByResponseDTO(createdBy);
+
+        //then
+        assertNotNull(createdByResponseDTO);
+        assertEquals("abc-123", createdByResponseDTO.getId());
+        assertEquals("jb@ch.gov.uk", createdByResponseDTO.getEmail());
+        assertEquals("Joe Bloggs", createdByResponseDTO.getFullName());
+        assertTrue( createdByResponseDTO.isShareIdentity());
     }
 
     @Test


### PR DESCRIPTION
Just updated the two PRs - the created by returned when GET is called for display on the check your answers page was left as it was the thing causing problems with serialization earlier - but if I add a DTO for created by then the var can be reformatted here as well.