### PR TITLE
OBJ-312 include chips contact fields in objectons api client

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequest.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequest.java
@@ -85,10 +85,15 @@ public class ChipsRequest {
 
     @Override
     public String toString() {
+        StringBuilder sb = new StringBuilder();
+        for(String key : attachments.keySet()) {
+            sb.append(String.format("%s:%s,", key, attachments.get(key)));
+        }
+        String attachments = sb.toString().substring(0, sb.length()-1);
         return "ChipsRequest{" +
             "objectionId='" + objectionId + '\'' +
             ",companyNumber='" + companyNumber + '\'' +
-            ",attachments='" + attachments.values() + '\'' +
+            ",attachments='" + attachments + '\'' +
             ",referenceNumber='" + referenceNumber + '\'' +
             ",customerEmail='" + customerEmail + '\'' +
             ",reason='" + reason + '\'' +

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequest.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequest.java
@@ -1,6 +1,13 @@
 package uk.gov.companieshouse.api.strikeoffobjections.model.chips;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
+import uk.gov.companieshouse.service.links.CoreLinkKeys;
+import uk.gov.companieshouse.service.links.Links;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ChipsRequest {
 
@@ -10,9 +17,27 @@ public class ChipsRequest {
     @JsonProperty("company_number")
     private final String companyNumber;
 
-    public ChipsRequest(String objectionId, String companyNumber) {
+    @JsonProperty("attachments")
+    private final Map<String, String> attachments;
+
+    @JsonProperty("reference_number")
+    private final String referenceNumber;
+
+    @JsonProperty("customer_email")
+    private final String customerEmail;
+
+    @JsonProperty("reason")
+    private final String reason;
+
+    public ChipsRequest(String objectionId, String companyNumber,
+                        List<Attachment> attachments,
+                        String customerEmail, String reason) {
         this.objectionId = objectionId;
         this.companyNumber = companyNumber;
+        this.attachments = buildAttachmentsMap(attachments);
+        this.referenceNumber = ""; // TODO OBJ-162 add ref number
+        this.customerEmail = customerEmail;
+        this.reason = reason;
     }
 
     public String getObjectionId() {
@@ -23,11 +48,43 @@ public class ChipsRequest {
         return companyNumber;
     }
 
+    public Map<String, String> getAttachments() {
+        return attachments;
+    }
+
+    public String getReferenceNumber() {
+        return referenceNumber;
+    }
+
+    public String getCustomerEmail() {
+        return customerEmail;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    private Map<String, String> buildAttachmentsMap(List<Attachment> attachments) {
+        Map<String, String> attachmentsMap = new HashMap<>();
+        for (Attachment attachment : attachments) {
+            String name = attachment.getName();
+            Links links = attachment.getLinks();
+            if(links != null) {
+                attachmentsMap.put(name, links.getLink(CoreLinkKeys.SELF));
+            }
+        }
+        return attachmentsMap;
+    }
+
     @Override
     public String toString() {
         return "ChipsRequest{" +
             "objectionId='" + objectionId + '\'' +
             ",companyNumber='" + companyNumber + '\'' +
+            ",attachments='" + attachments.values() + '\'' +
+            ",referenceNumber='" + referenceNumber + '\'' +
+            ",customerEmail='" + customerEmail + '\'' +
+            ",reason='" + reason + '\'' +
             "}";
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequest.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequest.java
@@ -30,12 +30,13 @@ public class ChipsRequest {
     private final String reason;
 
     public ChipsRequest(String objectionId, String companyNumber,
-                        List<Attachment> attachments,
-                        String customerEmail, String reason) {
+                        List<Attachment> attachments, String referenceNumber,
+                        String customerEmail, String reason,
+                        String dowloadPrefix) {
         this.objectionId = objectionId;
         this.companyNumber = companyNumber;
-        this.attachments = buildAttachmentsMap(attachments);
-        this.referenceNumber = ""; // TODO OBJ-162 add ref number
+        this.attachments = buildAttachmentsMap(dowloadPrefix, attachments);
+        this.referenceNumber = referenceNumber;
         this.customerEmail = customerEmail;
         this.reason = reason;
     }
@@ -64,13 +65,16 @@ public class ChipsRequest {
         return reason;
     }
 
-    private Map<String, String> buildAttachmentsMap(List<Attachment> attachments) {
+    private Map<String, String> buildAttachmentsMap(String dowloadPrefix,
+                                                    List<Attachment> attachments) {
         Map<String, String> attachmentsMap = new HashMap<>();
         for (Attachment attachment : attachments) {
             String name = attachment.getName();
             Links links = attachment.getLinks();
             if(links != null) {
-                attachmentsMap.put(name, links.getLink(CoreLinkKeys.SELF));
+                String downloadLink = String.format("%s%s", dowloadPrefix,
+                        links.getLink(CoreLinkKeys.SELF));
+                attachmentsMap.put(name, downloadLink);
             }
         }
         return attachmentsMap;

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequest.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequest.java
@@ -89,7 +89,7 @@ public class ChipsRequest {
         for(String key : attachments.keySet()) {
             sb.append(String.format("%s:%s,", key, attachments.get(key)));
         }
-        String attachments = sb.toString().substring(0, sb.length()-1);
+        String attachments = sb.toString().substring(0, sb.length()-2);
         return "ChipsRequest{" +
             "objectionId='" + objectionId + '\'' +
             ",companyNumber='" + companyNumber + '\'' +

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequest.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequest.java
@@ -32,10 +32,10 @@ public class ChipsRequest {
     public ChipsRequest(String objectionId, String companyNumber,
                         List<Attachment> attachments, String referenceNumber,
                         String customerEmail, String reason,
-                        String dowloadPrefix) {
+                        String downloadPrefix) {
         this.objectionId = objectionId;
         this.companyNumber = companyNumber;
-        this.attachments = buildAttachmentsMap(dowloadPrefix, attachments);
+        this.attachments = buildAttachmentsMap(downloadPrefix, attachments);
         this.referenceNumber = referenceNumber;
         this.customerEmail = customerEmail;
         this.reason = reason;
@@ -65,14 +65,14 @@ public class ChipsRequest {
         return reason;
     }
 
-    private Map<String, String> buildAttachmentsMap(String dowloadPrefix,
+    private Map<String, String> buildAttachmentsMap(String downloadPrefix,
                                                     List<Attachment> attachments) {
         Map<String, String> attachmentsMap = new HashMap<>();
         for (Attachment attachment : attachments) {
             String name = attachment.getName();
             Links links = attachment.getLinks();
             if(links != null) {
-                String downloadLink = String.format("%s%s", dowloadPrefix,
+                String downloadLink = String.format("%s%s", downloadPrefix,
                         links.getLink(CoreLinkKeys.SELF));
                 attachmentsMap.put(name, downloadLink);
             }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequest.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequest.java
@@ -29,9 +29,12 @@ public class ChipsRequest {
     @JsonProperty("reason")
     private final String reason;
 
-    public ChipsRequest(String objectionId, String companyNumber,
-                        List<Attachment> attachments, String referenceNumber,
-                        String customerEmail, String reason,
+    public ChipsRequest(String objectionId,
+                        String companyNumber,
+                        List<Attachment> attachments,
+                        String referenceNumber,
+                        String customerEmail,
+                        String reason,
                         String downloadPrefix) {
         this.objectionId = objectionId;
         this.companyNumber = companyNumber;

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequest.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequest.java
@@ -2,7 +2,7 @@ package uk.gov.companieshouse.api.strikeoffobjections.model.chips;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
-import uk.gov.companieshouse.service.links.CoreLinkKeys;
+import uk.gov.companieshouse.api.strikeoffobjections.model.entity.ObjectionLinkKeys;
 import uk.gov.companieshouse.service.links.Links;
 
 import java.util.HashMap;
@@ -76,7 +76,7 @@ public class ChipsRequest {
             Links links = attachment.getLinks();
             if(links != null) {
                 String downloadLink = String.format("%s%s", downloadPrefix,
-                        links.getLink(CoreLinkKeys.SELF));
+                        links.getLink(ObjectionLinkKeys.DOWNLOAD));
                 attachmentsMap.put(name, downloadLink);
             }
         }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsService.java
@@ -22,7 +22,10 @@ public class ChipsService implements IChipsService {
     public void sendObjection(String requestId, Objection objection) {
         ChipsRequest chipsRequest = new ChipsRequest(
                 objection.getId(),
-                objection.getCompanyNumber()
+                objection.getCompanyNumber(),
+                objection.getAttachments(),
+                objection.getCreatedBy().getEmail(),
+                objection.getReason()
         );
 
         this.chipsClient.sendToChips(requestId, chipsRequest);

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsService.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.api.strikeoffobjections.service.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import uk.gov.companieshouse.api.strikeoffobjections.chips.ChipsClient;
@@ -10,6 +11,9 @@ import uk.gov.companieshouse.api.strikeoffobjections.service.IChipsService;
 
 @Service
 public class ChipsService implements IChipsService {
+
+    @Value("${EMAIL_ATTACHMENT_DOWNLOAD_URL_PREFIX}")
+    private String attachmentDownloadUrlPrefix;
 
     private final ChipsClient chipsClient;
 
@@ -24,8 +28,10 @@ public class ChipsService implements IChipsService {
                 objection.getId(),
                 objection.getCompanyNumber(),
                 objection.getAttachments(),
+                objection.getId(),
                 objection.getCreatedBy().getEmail(),
-                objection.getReason()
+                objection.getReason(),
+                attachmentDownloadUrlPrefix
         );
 
         this.chipsClient.sendToChips(requestId, chipsRequest);

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsService.java
@@ -28,7 +28,7 @@ public class ChipsService implements IChipsService {
                 objection.getId(),
                 objection.getCompanyNumber(),
                 objection.getAttachments(),
-                objection.getId(),
+                objection.getId(), // TODO OBJ-162 add ref number
                 objection.getCreatedBy().getEmail(),
                 objection.getReason(),
                 attachmentDownloadUrlPrefix

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/chips/ChipsClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/chips/ChipsClientTest.java
@@ -25,8 +25,8 @@ import static org.mockito.Mockito.when;
 @Unit
 @ExtendWith(MockitoExtension.class)
 class ChipsClientTest {
-
     private static final String REQUEST_ID = "test123";
+    private static final String OBJECTION_ID = "OBJECTION_ID";
     private static final String COMPANY_NUMBER = "12345678";
     private static final List<Attachment> ATTACHMENTS = new ArrayList<>();
     private static final String CUSTOMER_EMAIL = "test123@ch.gov.uk";
@@ -48,10 +48,10 @@ class ChipsClientTest {
         Utils.setTestAttachmentsWithLinks(ATTACHMENTS);
         ReflectionTestUtils.setField(chipsClient, "chipsRestUrl", CHIPS_REST_URL);
         ChipsRequest chipsRequest = new ChipsRequest(
-                REQUEST_ID,
+                OBJECTION_ID,
                 COMPANY_NUMBER,
                 ATTACHMENTS,
-                REQUEST_ID,
+                OBJECTION_ID,
                 CUSTOMER_EMAIL,
                 REASON,
                 DOWNLOAD_URL_PREFIX

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/chips/ChipsClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/chips/ChipsClientTest.java
@@ -18,7 +18,6 @@ import uk.gov.companieshouse.api.strikeoffobjections.utils.Utils;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,7 +26,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class ChipsClientTest {
 
-    private static final String OBJECTION_ID = "test123";
+    private static final String REQUEST_ID = "test123";
     private static final String COMPANY_NUMBER = "12345678";
     private static final List<Attachment> ATTACHMENTS = new ArrayList<>();
     private static final String CUSTOMER_EMAIL = "test123@ch.gov.uk";
@@ -49,10 +48,10 @@ class ChipsClientTest {
         Utils.setTestAttachmentsWithLinks(ATTACHMENTS);
         ReflectionTestUtils.setField(chipsClient, "chipsRestUrl", CHIPS_REST_URL);
         ChipsRequest chipsRequest = new ChipsRequest(
-                OBJECTION_ID,
+                REQUEST_ID,
                 COMPANY_NUMBER,
                 ATTACHMENTS,
-                OBJECTION_ID,
+                REQUEST_ID,
                 CUSTOMER_EMAIL,
                 REASON,
                 DOWNLOAD_URL_PREFIX
@@ -60,7 +59,7 @@ class ChipsClientTest {
 
         when(restTemplate.postForEntity(CHIPS_REST_URL, chipsRequest, String.class)).thenReturn(new ResponseEntity<>(HttpStatus.OK));
 
-        chipsClient.sendToChips(OBJECTION_ID, chipsRequest);
+        chipsClient.sendToChips(REQUEST_ID, chipsRequest);
         verify(restTemplate, times(1)).postForEntity(CHIPS_REST_URL, chipsRequest, String.class);
     }
 

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/chips/ChipsClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/chips/ChipsClientTest.java
@@ -14,13 +14,9 @@ import uk.gov.companieshouse.api.strikeoffobjections.groups.Unit;
 import uk.gov.companieshouse.api.strikeoffobjections.model.chips.ChipsRequest;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
 import uk.gov.companieshouse.api.strikeoffobjections.utils.Utils;
-import uk.gov.companieshouse.service.links.CoreLinkKeys;
-import uk.gov.companieshouse.service.links.Links;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.times;
@@ -31,12 +27,13 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class ChipsClientTest {
 
-    private static final String REQUEST_ID = "test123";
+    private static final String OBJECTION_ID = "test123";
     private static final String COMPANY_NUMBER = "12345678";
     private static final List<Attachment> ATTACHMENTS = new ArrayList<>();
     private static final String CUSTOMER_EMAIL = "test123@ch.gov.uk";
     private static final String REASON = "This is a test";
     private static final String CHIPS_REST_URL = "test.url";
+    private static final String DOWNLOAD_URL_PREFIX = "http://chs-test-web:4000/strike-off-objections/download";
 
     @InjectMocks
     private ChipsClient chipsClient;
@@ -52,20 +49,18 @@ class ChipsClientTest {
         Utils.setTestAttachmentsWithLinks(ATTACHMENTS);
         ReflectionTestUtils.setField(chipsClient, "chipsRestUrl", CHIPS_REST_URL);
         ChipsRequest chipsRequest = new ChipsRequest(
-                REQUEST_ID,
+                OBJECTION_ID,
                 COMPANY_NUMBER,
                 ATTACHMENTS,
+                OBJECTION_ID,
                 CUSTOMER_EMAIL,
-                REASON
+                REASON,
+                DOWNLOAD_URL_PREFIX
         );
 
-        assertEquals("link to SELF 1",
-        chipsRequest.getAttachments().get("TestAttachment1"));
-        assertEquals("link to SELF 2",
-                chipsRequest.getAttachments().get("TestAttachment2"));
         when(restTemplate.postForEntity(CHIPS_REST_URL, chipsRequest, String.class)).thenReturn(new ResponseEntity<>(HttpStatus.OK));
 
-        chipsClient.sendToChips(REQUEST_ID, chipsRequest);
+        chipsClient.sendToChips(OBJECTION_ID, chipsRequest);
         verify(restTemplate, times(1)).postForEntity(CHIPS_REST_URL, chipsRequest, String.class);
     }
 

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/chips/ChipsClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/chips/ChipsClientTest.java
@@ -12,7 +12,17 @@ import org.springframework.web.client.RestTemplate;
 import uk.gov.companieshouse.api.strikeoffobjections.common.ApiLogger;
 import uk.gov.companieshouse.api.strikeoffobjections.groups.Unit;
 import uk.gov.companieshouse.api.strikeoffobjections.model.chips.ChipsRequest;
+import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
+import uk.gov.companieshouse.api.strikeoffobjections.utils.Utils;
+import uk.gov.companieshouse.service.links.CoreLinkKeys;
+import uk.gov.companieshouse.service.links.Links;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -23,6 +33,9 @@ class ChipsClientTest {
 
     private static final String REQUEST_ID = "test123";
     private static final String COMPANY_NUMBER = "12345678";
+    private static final List<Attachment> ATTACHMENTS = new ArrayList<>();
+    private static final String CUSTOMER_EMAIL = "test123@ch.gov.uk";
+    private static final String REASON = "This is a test";
     private static final String CHIPS_REST_URL = "test.url";
 
     @InjectMocks
@@ -35,16 +48,25 @@ class ChipsClientTest {
     private RestTemplate restTemplate;
 
     @Test
-    void testSendMessageToChips(){
+    void testSendMessageToChips() {
+        Utils.setTestAttachmentsWithLinks(ATTACHMENTS);
         ReflectionTestUtils.setField(chipsClient, "chipsRestUrl", CHIPS_REST_URL);
         ChipsRequest chipsRequest = new ChipsRequest(
                 REQUEST_ID,
-                COMPANY_NUMBER
+                COMPANY_NUMBER,
+                ATTACHMENTS,
+                CUSTOMER_EMAIL,
+                REASON
         );
 
+        assertEquals("link to SELF 1",
+        chipsRequest.getAttachments().get("TestAttachment1"));
+        assertEquals("link to SELF 2",
+                chipsRequest.getAttachments().get("TestAttachment2"));
         when(restTemplate.postForEntity(CHIPS_REST_URL, chipsRequest, String.class)).thenReturn(new ResponseEntity<>(HttpStatus.OK));
 
         chipsClient.sendToChips(REQUEST_ID, chipsRequest);
         verify(restTemplate, times(1)).postForEntity(CHIPS_REST_URL, chipsRequest, String.class);
     }
+
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ChipsRequestTest {
 
-    private static final String OBJECTION_ID = "test123";
+    private static final String REQUEST_ID = "test123";
     private static final String COMPANY_NUMBER = "12345678";
     private static final List<Attachment> ATTACHMENTS = new ArrayList<>();
     private static final String CUSTOMER_EMAIL = "test123@ch.gov.uk";
@@ -23,10 +23,10 @@ class ChipsRequestTest {
     {
         Utils.setTestAttachmentsWithLinks(ATTACHMENTS);
         ChipsRequest chipsRequest = new ChipsRequest(
-                OBJECTION_ID,
+                REQUEST_ID,
                 COMPANY_NUMBER,
                 ATTACHMENTS,
-                OBJECTION_ID,
+                REQUEST_ID,
                 CUSTOMER_EMAIL,
                 REASON,
                 DOWNLOAD_URL_PREFIX
@@ -38,7 +38,7 @@ class ChipsRequestTest {
                 chipsRequest.getAttachments().get("TestAttachment1"));
         assertEquals(String.format("%s/url2/download", DOWNLOAD_URL_PREFIX),
                 chipsRequest.getAttachments().get("TestAttachment2"));
-        assertEquals(OBJECTION_ID, chipsRequest.getReferenceNumber());
+        assertEquals(REQUEST_ID, chipsRequest.getReferenceNumber());
         assertEquals(CUSTOMER_EMAIL, chipsRequest.getCustomerEmail());
         assertEquals(REASON, chipsRequest.getReason());
     }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
@@ -1,0 +1,45 @@
+package uk.gov.companieshouse.api.strikeoffobjections.model.chips;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
+import uk.gov.companieshouse.api.strikeoffobjections.utils.Utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ChipsRequestTest {
+
+    private static final String OBJECTION_ID = "test123";
+    private static final String COMPANY_NUMBER = "12345678";
+    private static final List<Attachment> ATTACHMENTS = new ArrayList<>();
+    private static final String CUSTOMER_EMAIL = "test123@ch.gov.uk";
+    private static final String REASON = "This is a test";
+    private static final String DOWNLOAD_URL_PREFIX = "http://chs-test-web:4000/strike-off-objections/download";
+
+    @Test
+    public void testFieldsAndAttachmentConstruction()
+    {
+        Utils.setTestAttachmentsWithLinks(ATTACHMENTS);
+        ChipsRequest chipsRequest = new ChipsRequest(
+                OBJECTION_ID,
+                COMPANY_NUMBER,
+                ATTACHMENTS,
+                OBJECTION_ID,
+                CUSTOMER_EMAIL,
+                REASON,
+                DOWNLOAD_URL_PREFIX
+        );
+
+
+        assertEquals(COMPANY_NUMBER, chipsRequest.getCompanyNumber());
+        assertEquals(String.format("%s/url1", DOWNLOAD_URL_PREFIX),
+                chipsRequest.getAttachments().get("TestAttachment1"));
+        assertEquals(String.format("%s/url2", DOWNLOAD_URL_PREFIX),
+                chipsRequest.getAttachments().get("TestAttachment2"));
+        assertEquals(OBJECTION_ID, chipsRequest.getReferenceNumber());
+        assertEquals(CUSTOMER_EMAIL, chipsRequest.getCustomerEmail());
+        assertEquals(REASON, chipsRequest.getReason());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ChipsRequestTest {
+class ChipsRequestTest {
 
     private static final String OBJECTION_ID = "test123";
     private static final String COMPANY_NUMBER = "12345678";
@@ -19,7 +19,7 @@ public class ChipsRequestTest {
     private static final String DOWNLOAD_URL_PREFIX = "http://chs-test-web:4000/strike-off-objections/download";
 
     @Test
-    public void testFieldsAndAttachmentConstruction()
+    void testFieldsAndAttachmentConstruction()
     {
         Utils.setTestAttachmentsWithLinks(ATTACHMENTS);
         ChipsRequest chipsRequest = new ChipsRequest(

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ChipsRequestTest {
 
-    private static final String REQUEST_ID = "test123";
+    private static final String OBJECTION_ID = "test123";
     private static final String COMPANY_NUMBER = "12345678";
     private static final List<Attachment> ATTACHMENTS = new ArrayList<>();
     private static final String CUSTOMER_EMAIL = "test123@ch.gov.uk";
@@ -23,10 +23,10 @@ class ChipsRequestTest {
     {
         Utils.setTestAttachmentsWithLinks(ATTACHMENTS);
         ChipsRequest chipsRequest = new ChipsRequest(
-                REQUEST_ID,
+                OBJECTION_ID,
                 COMPANY_NUMBER,
                 ATTACHMENTS,
-                REQUEST_ID,
+                OBJECTION_ID,
                 CUSTOMER_EMAIL,
                 REASON,
                 DOWNLOAD_URL_PREFIX
@@ -38,7 +38,7 @@ class ChipsRequestTest {
                 chipsRequest.getAttachments().get("TestAttachment1"));
         assertEquals(String.format("%s/url2/download", DOWNLOAD_URL_PREFIX),
                 chipsRequest.getAttachments().get("TestAttachment2"));
-        assertEquals(REQUEST_ID, chipsRequest.getReferenceNumber());
+        assertEquals(OBJECTION_ID, chipsRequest.getReferenceNumber());
         assertEquals(CUSTOMER_EMAIL, chipsRequest.getCustomerEmail());
         assertEquals(REASON, chipsRequest.getReason());
     }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
@@ -34,9 +34,9 @@ class ChipsRequestTest {
 
 
         assertEquals(COMPANY_NUMBER, chipsRequest.getCompanyNumber());
-        assertEquals(String.format("%s/url1", DOWNLOAD_URL_PREFIX),
+        assertEquals(String.format("%s/url1/download", DOWNLOAD_URL_PREFIX),
                 chipsRequest.getAttachments().get("TestAttachment1"));
-        assertEquals(String.format("%s/url2", DOWNLOAD_URL_PREFIX),
+        assertEquals(String.format("%s/url2/download", DOWNLOAD_URL_PREFIX),
                 chipsRequest.getAttachments().get("TestAttachment2"));
         assertEquals(OBJECTION_ID, chipsRequest.getReferenceNumber());
         assertEquals(CUSTOMER_EMAIL, chipsRequest.getCustomerEmail());

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsServiceTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,9 +19,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.strikeoffobjections.chips.ChipsClient;
 import uk.gov.companieshouse.api.strikeoffobjections.groups.Unit;
 import uk.gov.companieshouse.api.strikeoffobjections.model.chips.ChipsRequest;
+import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
 import uk.gov.companieshouse.api.strikeoffobjections.utils.Utils;
 import uk.gov.companieshouse.service.ServiceException;
+import uk.gov.companieshouse.service.links.CoreLinkKeys;
 
 @Unit
 @ExtendWith(MockitoExtension.class)
@@ -44,6 +48,9 @@ public class ChipsServiceTest {
         Objection objection = Utils.getTestObjection(
                 OBJECTION_ID, REASON, COMPANY_NUMBER, USER_ID, EMAIL, LOCAL_DATE_TIME,
                 Utils.buildTestObjectionCreate("Joe Bloggs", false));
+        List<Attachment> attachments = new ArrayList<>();
+        Utils.setTestAttachmentsWithLinks(attachments);
+        objection.setAttachments(attachments);
 
         chipsService.sendObjection(REQUEST_ID, objection);
         ArgumentCaptor<ChipsRequest> chipsRequestArgumentCaptor = ArgumentCaptor.forClass(ChipsRequest.class);
@@ -54,5 +61,12 @@ public class ChipsServiceTest {
 
         assertEquals(COMPANY_NUMBER, chipsRequest.getCompanyNumber());
         assertEquals(OBJECTION_ID, chipsRequest.getObjectionId());
+        assertEquals(EMAIL, chipsRequest.getCustomerEmail());
+        assertEquals(REASON, chipsRequest.getReason());
+
+        assertEquals("link to SELF 1",
+                chipsRequest.getAttachments().get("TestAttachment1"));
+        assertEquals("link to SELF 2",
+                chipsRequest.getAttachments().get("TestAttachment2"));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsServiceTest.java
@@ -66,9 +66,9 @@ public class ChipsServiceTest {
         assertEquals(EMAIL, chipsRequest.getCustomerEmail());
         assertEquals(REASON, chipsRequest.getReason());
 
-        assertEquals(String.format("%s/url1", DOWNLOAD_URL_PREFIX),
+        assertEquals(String.format("%s/url1/download", DOWNLOAD_URL_PREFIX),
                 chipsRequest.getAttachments().get("TestAttachment1"));
-        assertEquals(String.format("%s/url2", DOWNLOAD_URL_PREFIX),
+        assertEquals(String.format("%s/url2/download", DOWNLOAD_URL_PREFIX),
                 chipsRequest.getAttachments().get("TestAttachment2"));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsServiceTest.java
@@ -29,6 +29,7 @@ import uk.gov.companieshouse.service.ServiceException;
 @ExtendWith(MockitoExtension.class)
 public class ChipsServiceTest {
 
+    private static final String REQUEST_ID = "test123";
     private static final String OBJECTION_ID = "OBJECTION_ID";
     private static final String COMPANY_NUMBER = "COMPANY_NUMBER";
     private static final LocalDateTime LOCAL_DATE_TIME = LocalDateTime.of(2020, 12, 10, 8, 0);
@@ -53,10 +54,10 @@ public class ChipsServiceTest {
         Utils.setTestAttachmentsWithLinks(attachments);
         objection.setAttachments(attachments);
 
-        chipsService.sendObjection(OBJECTION_ID, objection);
+        chipsService.sendObjection(REQUEST_ID, objection);
         ArgumentCaptor<ChipsRequest> chipsRequestArgumentCaptor = ArgumentCaptor.forClass(ChipsRequest.class);
 
-        verify(chipsClient, times(1)).sendToChips(eq(OBJECTION_ID), chipsRequestArgumentCaptor.capture());
+        verify(chipsClient, times(1)).sendToChips(eq(REQUEST_ID), chipsRequestArgumentCaptor.capture());
 
         ChipsRequest chipsRequest = chipsRequestArgumentCaptor.getValue();
 

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.api.strikeoffobjections.chips.ChipsClient;
 import uk.gov.companieshouse.api.strikeoffobjections.groups.Unit;
 import uk.gov.companieshouse.api.strikeoffobjections.model.chips.ChipsRequest;
@@ -23,19 +24,18 @@ import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
 import uk.gov.companieshouse.api.strikeoffobjections.utils.Utils;
 import uk.gov.companieshouse.service.ServiceException;
-import uk.gov.companieshouse.service.links.CoreLinkKeys;
 
 @Unit
 @ExtendWith(MockitoExtension.class)
 public class ChipsServiceTest {
 
-    private static final String REQUEST_ID = "REQUEST_ID";
+    private static final String OBJECTION_ID = "OBJECTION_ID";
     private static final String COMPANY_NUMBER = "COMPANY_NUMBER";
     private static final LocalDateTime LOCAL_DATE_TIME = LocalDateTime.of(2020, 12, 10, 8, 0);
-    private static final String OBJECTION_ID = "OBJECTION_ID";
     private static final String EMAIL = "demo@ch.gov.uk";
     private static final String USER_ID = "32324";
     private static final String REASON = "THIS IS A REASON";
+    private static final String DOWNLOAD_URL_PREFIX = "http://chs-test-web:4000/strike-off-objections/download";
 
     @Mock
     private ChipsClient chipsClient;
@@ -45,6 +45,7 @@ public class ChipsServiceTest {
 
     @Test
     void testSendingToChipsCreatesCorrectRequest() throws ServiceException {
+        ReflectionTestUtils.setField(chipsService, "attachmentDownloadUrlPrefix", DOWNLOAD_URL_PREFIX);
         Objection objection = Utils.getTestObjection(
                 OBJECTION_ID, REASON, COMPANY_NUMBER, USER_ID, EMAIL, LOCAL_DATE_TIME,
                 Utils.buildTestObjectionCreate("Joe Bloggs", false));
@@ -52,21 +53,22 @@ public class ChipsServiceTest {
         Utils.setTestAttachmentsWithLinks(attachments);
         objection.setAttachments(attachments);
 
-        chipsService.sendObjection(REQUEST_ID, objection);
+        chipsService.sendObjection(OBJECTION_ID, objection);
         ArgumentCaptor<ChipsRequest> chipsRequestArgumentCaptor = ArgumentCaptor.forClass(ChipsRequest.class);
 
-        verify(chipsClient, times(1)).sendToChips(eq(REQUEST_ID), chipsRequestArgumentCaptor.capture());
+        verify(chipsClient, times(1)).sendToChips(eq(OBJECTION_ID), chipsRequestArgumentCaptor.capture());
 
         ChipsRequest chipsRequest = chipsRequestArgumentCaptor.getValue();
 
         assertEquals(COMPANY_NUMBER, chipsRequest.getCompanyNumber());
         assertEquals(OBJECTION_ID, chipsRequest.getObjectionId());
+        assertEquals(OBJECTION_ID, chipsRequest.getReferenceNumber());
         assertEquals(EMAIL, chipsRequest.getCustomerEmail());
         assertEquals(REASON, chipsRequest.getReason());
 
-        assertEquals("link to SELF 1",
+        assertEquals(String.format("%s/url1", DOWNLOAD_URL_PREFIX),
                 chipsRequest.getAttachments().get("TestAttachment1"));
-        assertEquals("link to SELF 2",
+        assertEquals(String.format("%s/url2", DOWNLOAD_URL_PREFIX),
                 chipsRequest.getAttachments().get("TestAttachment2"));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/utils/Utils.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/utils/Utils.java
@@ -100,12 +100,12 @@ public class Utils {
     public static void setTestAttachmentsWithLinks(List<Attachment> attachments) {
         Attachment attachment1 = Utils.buildTestAttachment("id1", "TestAttachment1");
         Links links1 = new Links();
-        links1.setLink(CoreLinkKeys.SELF, "link to SELF 1");
+        links1.setLink(CoreLinkKeys.SELF, "/url1");
         attachment1.setLinks(links1);
         attachments.add(attachment1);
         Attachment attachment2 = Utils.buildTestAttachment("id1", "TestAttachment2");
         Links links2 = new Links();
-        links2.setLink(CoreLinkKeys.SELF, "link to SELF 2");
+        links2.setLink(CoreLinkKeys.SELF, "/url2");
         attachment2.setLinks(links2);
         attachments.add(attachment2);
     }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/utils/Utils.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/utils/Utils.java
@@ -16,6 +16,7 @@ import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.CreatedBy;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
 import uk.gov.companieshouse.api.strikeoffobjections.model.email.EmailContent;
+import uk.gov.companieshouse.api.strikeoffobjections.model.entity.ObjectionLinkKeys;
 import uk.gov.companieshouse.service.links.CoreLinkKeys;
 import uk.gov.companieshouse.service.links.Links;
 
@@ -100,12 +101,12 @@ public class Utils {
     public static void setTestAttachmentsWithLinks(List<Attachment> attachments) {
         Attachment attachment1 = Utils.buildTestAttachment("id1", "TestAttachment1");
         Links links1 = new Links();
-        links1.setLink(CoreLinkKeys.SELF, "/url1");
+        links1.setLink(ObjectionLinkKeys.DOWNLOAD, "/url1/download");
         attachment1.setLinks(links1);
         attachments.add(attachment1);
         Attachment attachment2 = Utils.buildTestAttachment("id1", "TestAttachment2");
         Links links2 = new Links();
-        links2.setLink(CoreLinkKeys.SELF, "/url2");
+        links2.setLink(ObjectionLinkKeys.DOWNLOAD, "/url2/download");
         attachment2.setLinks(links2);
         attachments.add(attachment2);
     }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/utils/Utils.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/utils/Utils.java
@@ -16,6 +16,8 @@ import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.CreatedBy;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
 import uk.gov.companieshouse.api.strikeoffobjections.model.email.EmailContent;
+import uk.gov.companieshouse.service.links.CoreLinkKeys;
+import uk.gov.companieshouse.service.links.Links;
 
 import java.io.File;
 import java.io.IOException;
@@ -93,6 +95,19 @@ public class Utils {
         attachment.setId(id);
         attachment.setName(name);
         return attachment;
+    }
+
+    public static void setTestAttachmentsWithLinks(List<Attachment> attachments) {
+        Attachment attachment1 = Utils.buildTestAttachment("id1", "TestAttachment1");
+        Links links1 = new Links();
+        links1.setLink(CoreLinkKeys.SELF, "link to SELF 1");
+        attachment1.setLinks(links1);
+        attachments.add(attachment1);
+        Attachment attachment2 = Utils.buildTestAttachment("id1", "TestAttachment2");
+        Links links2 = new Links();
+        links2.setLink(CoreLinkKeys.SELF, "link to SELF 2");
+        attachment2.setLinks(links2);
+        attachments.add(attachment2);
     }
 
     public static MultipartFile mockMultipartFile() throws IOException {


### PR DESCRIPTION
Added the 4 new fields to the ChipsRequest object:

**attachments** - map with name and url string taken from links with the SELF key
**referenceNumber** - empty string for now to be implemented i OBJ-162
**customerEmai**l
**reason**