### PR TITLE
OBJ-312 Adding null checks for attachments in ChipsRequest

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequest.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequest.java
@@ -1,10 +1,12 @@
 package uk.gov.companieshouse.api.strikeoffobjections.model.chips;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.StringUtils;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.ObjectionLinkKeys;
 import uk.gov.companieshouse.service.links.Links;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,11 +72,15 @@ public class ChipsRequest {
 
     private Map<String, String> buildAttachmentsMap(String downloadPrefix,
                                                     List<Attachment> attachments) {
+        if (attachments == null) {
+            return null;
+        }
+
         Map<String, String> attachmentsMap = new HashMap<>();
         for (Attachment attachment : attachments) {
             String name = attachment.getName();
             Links links = attachment.getLinks();
-            if(links != null) {
+            if (links != null) {
                 String downloadLink = String.format("%s%s", downloadPrefix,
                         links.getLink(ObjectionLinkKeys.DOWNLOAD));
                 attachmentsMap.put(name, downloadLink);
@@ -85,18 +91,17 @@ public class ChipsRequest {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        for(String key : attachments.keySet()) {
-            sb.append(String.format("%s:%s,", key, attachments.get(key)));
-        }
-        String attachments = sb.toString().substring(0, sb.length()-2);
         return "ChipsRequest{" +
             "objectionId='" + objectionId + '\'' +
             ",companyNumber='" + companyNumber + '\'' +
-            ",attachments='" + attachments + '\'' +
+            ",attachments='" + getAttachmentsAsString() + '\'' +
             ",referenceNumber='" + referenceNumber + '\'' +
             ",customerEmail='" + customerEmail + '\'' +
             ",reason='" + reason + '\'' +
             "}";
+    }
+
+    private String getAttachmentsAsString() {
+        return StringUtils.join(Collections.singleton(attachments), ',');
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
@@ -8,6 +8,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 
 class ChipsRequestTest {
 
@@ -19,8 +21,7 @@ class ChipsRequestTest {
     private static final String DOWNLOAD_URL_PREFIX = "http://chs-test-web:4000/strike-off-objections/download";
 
     @Test
-    void testFieldsAndAttachmentConstruction()
-    {
+    void testConstruction() {
         Utils.setTestAttachmentsWithLinks(ATTACHMENTS);
         ChipsRequest chipsRequest = new ChipsRequest(
                 OBJECTION_ID,
@@ -32,7 +33,6 @@ class ChipsRequestTest {
                 DOWNLOAD_URL_PREFIX
         );
 
-
         assertEquals(COMPANY_NUMBER, chipsRequest.getCompanyNumber());
         assertEquals(String.format("%s/url1/download", DOWNLOAD_URL_PREFIX),
                 chipsRequest.getAttachments().get("TestAttachment1"));
@@ -41,5 +41,44 @@ class ChipsRequestTest {
         assertEquals(OBJECTION_ID, chipsRequest.getReferenceNumber());
         assertEquals(CUSTOMER_EMAIL, chipsRequest.getCustomerEmail());
         assertEquals(REASON, chipsRequest.getReason());
+    }
+
+    @Test
+    void testConstructionWithNullAttachment() {
+        ChipsRequest chipsRequest = new ChipsRequest(
+                OBJECTION_ID,
+                COMPANY_NUMBER,
+                null,
+                OBJECTION_ID,
+                CUSTOMER_EMAIL,
+                REASON,
+                DOWNLOAD_URL_PREFIX
+        );
+
+        // should not throw null pointer exception
+        assertNull(chipsRequest.getAttachments());
+    }
+
+    @Test
+    void testToString() {
+        String expectedOutput = "ChipsRequest{objectionId='test123',companyNumber='12345678'," +
+                "attachments='{TestAttachment2=http://chs-test-web:4000/strike-off-objections/download/url2/download, " +
+                "TestAttachment1=http://chs-test-web:4000/strike-off-objections/download/url1/download}'," +
+                "referenceNumber='test123',customerEmail='test123@ch.gov.uk',reason='This is a test'}";
+
+        Utils.setTestAttachmentsWithLinks(ATTACHMENTS);
+        ChipsRequest chipsRequest = new ChipsRequest(
+                OBJECTION_ID,
+                COMPANY_NUMBER,
+                ATTACHMENTS,
+                OBJECTION_ID,
+                CUSTOMER_EMAIL,
+                REASON,
+                DOWNLOAD_URL_PREFIX
+        );
+
+        String actualOutput = chipsRequest.toString();
+
+        assertEquals(expectedOutput, actualOutput);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
@@ -81,4 +81,26 @@ class ChipsRequestTest {
 
         assertEquals(expectedOutput, actualOutput);
     }
+
+    @Test
+    void testToStringNullAttachments() {
+        String expectedOutput = "ChipsRequest{objectionId='test123',companyNumber='12345678',attachments=''," +
+                "referenceNumber='test123',customerEmail='test123@ch.gov.uk',reason='This is a test'}";
+
+
+        Utils.setTestAttachmentsWithLinks(ATTACHMENTS);
+        ChipsRequest chipsRequest = new ChipsRequest(
+                OBJECTION_ID,
+                COMPANY_NUMBER,
+                null,
+                OBJECTION_ID,
+                CUSTOMER_EMAIL,
+                REASON,
+                DOWNLOAD_URL_PREFIX
+        );
+
+        String actualOutput = chipsRequest.toString();
+
+        assertEquals(expectedOutput, actualOutput);
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
@@ -87,7 +87,6 @@ class ChipsRequestTest {
         String expectedOutput = "ChipsRequest{objectionId='test123',companyNumber='12345678',attachments=''," +
                 "referenceNumber='test123',customerEmail='test123@ch.gov.uk',reason='This is a test'}";
 
-
         Utils.setTestAttachmentsWithLinks(ATTACHMENTS);
         ChipsRequest chipsRequest = new ChipsRequest(
                 OBJECTION_ID,


### PR DESCRIPTION
Made the new attachments mapping null safe and found a neat way of converting the attachments map to a string (also null safe).
Added tests to cover these. 