### PR TITLE
Feature/obj 322 add eligibility endpoint

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
@@ -22,6 +22,7 @@ import uk.gov.companieshouse.api.strikeoffobjections.exception.AttachmentNotFoun
 import uk.gov.companieshouse.api.strikeoffobjections.exception.ObjectionNotFoundException;
 import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClientResponse;
 import uk.gov.companieshouse.api.strikeoffobjections.model.create.ObjectionCreate;
+import uk.gov.companieshouse.api.strikeoffobjections.model.eligibility.ObjectionEligibility;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.ObjectionStatus;
@@ -502,10 +503,10 @@ public class ObjectionController {
         }
     }
 
-    @GetMapping("/status")
-    public ResponseEntity<Boolean> isCompanyEligibleForObjection(@PathVariable("companyNumber") String companyNumber,
+    @GetMapping("/eligibility")
+    public ResponseEntity<ObjectionEligibility> isCompanyEligibleForObjection(@PathVariable("companyNumber") String companyNumber,
                                                                  @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
-        boolean result = objectionService.isCompanyEligible(companyNumber, requestId);
+        ObjectionEligibility result = objectionService.isCompanyEligible(companyNumber, requestId);
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionController.java
@@ -501,4 +501,11 @@ public class ObjectionController {
             );
         }
     }
+
+    @GetMapping("/status")
+    public ResponseEntity<Boolean> isCompanyEligibleForObjection(@PathVariable("companyNumber") String companyNumber,
+                                                                 @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
+        boolean result = objectionService.isCompanyEligible(companyNumber, requestId);
+        return new ResponseEntity<>(result, HttpStatus.OK);
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/eligibility/ObjectionEligibility.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/eligibility/ObjectionEligibility.java
@@ -1,0 +1,17 @@
+package uk.gov.companieshouse.api.strikeoffobjections.model.eligibility;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ObjectionEligibility {
+
+    @JsonProperty("is_eligible")
+    private boolean isEligible;
+
+    public boolean isEligible() {
+        return isEligible;
+    }
+
+    public void setEligible(boolean eligible) {
+        isEligible = eligible;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
@@ -43,4 +43,6 @@ public interface IObjectionService {
 
     FileTransferApiClientResponse downloadAttachment(
             String requestId, String objectionId, String attachmentId, HttpServletResponse response) throws ServiceException;
+
+    boolean isCompanyEligible(String companyNumber, String requestId);
 }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/IObjectionService.java
@@ -8,6 +8,7 @@ import uk.gov.companieshouse.api.strikeoffobjections.exception.InvalidObjectionS
 import uk.gov.companieshouse.api.strikeoffobjections.exception.ObjectionNotFoundException;
 import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClientResponse;
 import uk.gov.companieshouse.api.strikeoffobjections.model.create.ObjectionCreate;
+import uk.gov.companieshouse.api.strikeoffobjections.model.eligibility.ObjectionEligibility;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
 import uk.gov.companieshouse.api.strikeoffobjections.model.patch.ObjectionPatch;
@@ -44,5 +45,5 @@ public interface IObjectionService {
     FileTransferApiClientResponse downloadAttachment(
             String requestId, String objectionId, String attachmentId, HttpServletResponse response) throws ServiceException;
 
-    boolean isCompanyEligible(String companyNumber, String requestId);
+    ObjectionEligibility isCompanyEligible(String companyNumber, String requestId);
 }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
@@ -18,6 +18,7 @@ import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClient;
 import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClientResponse;
 import uk.gov.companieshouse.api.strikeoffobjections.file.ObjectionsLinkKeys;
 import uk.gov.companieshouse.api.strikeoffobjections.model.create.ObjectionCreate;
+import uk.gov.companieshouse.api.strikeoffobjections.model.eligibility.ObjectionEligibility;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.CreatedBy;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
@@ -135,11 +136,13 @@ public class ObjectionService implements IObjectionService {
         return objectionStatus;
     }
 
-    public boolean isCompanyEligible(String companyNumber, String requestId) {
+    public ObjectionEligibility isCompanyEligible(String companyNumber, String requestId) {
         Long actionCode = getActionCode(companyNumber, requestId);
         final ObjectionStatus objectionStatus = getObjectionStatusForCreate(actionCode, companyNumber, requestId);
 
-        return !objectionStatus.isIneligible();
+        ObjectionEligibility objectionEligibility = new ObjectionEligibility();
+        objectionEligibility.setEligible(!objectionStatus.isIneligible());
+        return objectionEligibility;
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
@@ -135,6 +135,13 @@ public class ObjectionService implements IObjectionService {
         return objectionStatus;
     }
 
+    public boolean isCompanyEligible(String companyNumber, String requestId) {
+        Long actionCode = getActionCode(companyNumber, requestId);
+        final ObjectionStatus objectionStatus = getObjectionStatusForCreate(actionCode, companyNumber, requestId);
+
+        return !objectionStatus.isIneligible();
+    }
+
     /**
      * Update the Objection data with the provided patch data
      * Triggers the processing of the Objection if status is changed

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
@@ -20,6 +20,7 @@ import uk.gov.companieshouse.api.strikeoffobjections.exception.ObjectionNotFound
 import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClientResponse;
 import uk.gov.companieshouse.api.strikeoffobjections.groups.Unit;
 import uk.gov.companieshouse.api.strikeoffobjections.model.create.ObjectionCreate;
+import uk.gov.companieshouse.api.strikeoffobjections.model.eligibility.ObjectionEligibility;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.CreatedBy;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
@@ -572,18 +573,22 @@ class ObjectionControllerTest {
 
     @Test
     public void isCompanyEligibleForObjectionTestTrueReturned() {
-        when(objectionService.isCompanyEligible(COMPANY_NUMBER, REQUEST_ID)).thenReturn(true);
-        ResponseEntity<Boolean> responseEntity = objectionController.isCompanyEligibleForObjection(COMPANY_NUMBER, REQUEST_ID);
+        ObjectionEligibility objectionEligibility = new ObjectionEligibility();
+        objectionEligibility.setEligible(true);
+        when(objectionService.isCompanyEligible(COMPANY_NUMBER, REQUEST_ID)).thenReturn(objectionEligibility);
+        ResponseEntity<ObjectionEligibility> responseEntity = objectionController.isCompanyEligibleForObjection(COMPANY_NUMBER, REQUEST_ID);
         assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
-        assertTrue(responseEntity.getBody());
+        assertTrue(responseEntity.getBody().isEligible());
     }
 
     @Test
     public void isCompanyEligibleForObjectionTestFalseReturned() {
-        when(objectionService.isCompanyEligible(COMPANY_NUMBER, REQUEST_ID)).thenReturn(false);
-        ResponseEntity<Boolean> responseEntity = objectionController.isCompanyEligibleForObjection(COMPANY_NUMBER, REQUEST_ID);
+        ObjectionEligibility objectionEligibility = new ObjectionEligibility();
+        objectionEligibility.setEligible(false);
+        when(objectionService.isCompanyEligible(COMPANY_NUMBER, REQUEST_ID)).thenReturn(objectionEligibility);
+        ResponseEntity<ObjectionEligibility> responseEntity = objectionController.isCompanyEligibleForObjection(COMPANY_NUMBER, REQUEST_ID);
         assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
-        assertFalse(responseEntity.getBody());
+        assertFalse(responseEntity.getBody().isEligible());
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
@@ -572,7 +572,7 @@ class ObjectionControllerTest {
     }
 
     @Test
-    public void isCompanyEligibleForObjectionTestTrueReturned() {
+    void isCompanyEligibleForObjectionTestTrueReturned() {
         ObjectionEligibility objectionEligibility = new ObjectionEligibility();
         objectionEligibility.setEligible(true);
         when(objectionService.isCompanyEligible(COMPANY_NUMBER, REQUEST_ID)).thenReturn(objectionEligibility);
@@ -582,7 +582,7 @@ class ObjectionControllerTest {
     }
 
     @Test
-    public void isCompanyEligibleForObjectionTestFalseReturned() {
+    void isCompanyEligibleForObjectionTestFalseReturned() {
         ObjectionEligibility objectionEligibility = new ObjectionEligibility();
         objectionEligibility.setEligible(false);
         when(objectionService.isCompanyEligible(COMPANY_NUMBER, REQUEST_ID)).thenReturn(objectionEligibility);

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
@@ -46,6 +46,7 @@ import java.util.List;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -568,4 +569,21 @@ class ObjectionControllerTest {
         assertNull(responseEntity.getBody());
         assertTrue(responseEntity.getHeaders().isEmpty());
     }
+
+    @Test
+    public void isCompanyEligibleForObjectionTestTrueReturned() {
+        when(objectionService.isCompanyEligible(COMPANY_NUMBER, REQUEST_ID)).thenReturn(true);
+        ResponseEntity<Boolean> responseEntity = objectionController.isCompanyEligibleForObjection(COMPANY_NUMBER, REQUEST_ID);
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertTrue(responseEntity.getBody());
+    }
+
+    @Test
+    public void isCompanyEligibleForObjectionTestFalseReturned() {
+        when(objectionService.isCompanyEligible(COMPANY_NUMBER, REQUEST_ID)).thenReturn(false);
+        ResponseEntity<Boolean> responseEntity = objectionController.isCompanyEligibleForObjection(COMPANY_NUMBER, REQUEST_ID);
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertFalse(responseEntity.getBody());
+    }
+
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
@@ -692,4 +692,29 @@ class ObjectionServiceTest {
         assertNotNull(downloadServiceResult);
         assertEquals(HttpStatus.OK, downloadServiceResult.getHttpStatus());
     }
+
+    @Test
+    void willReturnTrueEligibilityResponseWhenActionCodeOk() throws ValidationException {
+
+        when(oracleQueryClient.getCompanyActionCode(COMPANY_NUMBER)).thenReturn(ACTION_CODE_OK);
+        boolean response = objectionService.isCompanyEligible(COMPANY_NUMBER, REQUEST_ID);
+
+        verify(oracleQueryClient).getCompanyActionCode(COMPANY_NUMBER);
+        verify(actionCodeValidator).validate(ACTION_CODE_OK, REQUEST_ID);
+
+        assertTrue(response);
+    }
+
+    @Test
+    void willReturnFalseEligibilityResponseWhenActionCodeIneligible() throws ValidationException {
+
+        when(oracleQueryClient.getCompanyActionCode(COMPANY_NUMBER)).thenReturn(ACTION_CODE_INELIGIBLE);
+        doThrow(new ValidationException(INELIGIBLE_COMPANY_STRUCK_OFF)).when(actionCodeValidator).validate(ACTION_CODE_INELIGIBLE, REQUEST_ID);
+        boolean response = objectionService.isCompanyEligible(COMPANY_NUMBER, REQUEST_ID);
+
+        verify(oracleQueryClient).getCompanyActionCode(COMPANY_NUMBER);
+        verify(actionCodeValidator).validate(ACTION_CODE_INELIGIBLE, REQUEST_ID);
+
+        assertFalse(response);
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionServiceTest.java
@@ -21,6 +21,7 @@ import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClient;
 import uk.gov.companieshouse.api.strikeoffobjections.file.FileTransferApiClientResponse;
 import uk.gov.companieshouse.api.strikeoffobjections.file.ObjectionsLinkKeys;
 import uk.gov.companieshouse.api.strikeoffobjections.groups.Unit;
+import uk.gov.companieshouse.api.strikeoffobjections.model.eligibility.ObjectionEligibility;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.CreatedBy;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
@@ -697,12 +698,12 @@ class ObjectionServiceTest {
     void willReturnTrueEligibilityResponseWhenActionCodeOk() throws ValidationException {
 
         when(oracleQueryClient.getCompanyActionCode(COMPANY_NUMBER)).thenReturn(ACTION_CODE_OK);
-        boolean response = objectionService.isCompanyEligible(COMPANY_NUMBER, REQUEST_ID);
+        ObjectionEligibility response = objectionService.isCompanyEligible(COMPANY_NUMBER, REQUEST_ID);
 
         verify(oracleQueryClient).getCompanyActionCode(COMPANY_NUMBER);
         verify(actionCodeValidator).validate(ACTION_CODE_OK, REQUEST_ID);
 
-        assertTrue(response);
+        assertTrue(response.isEligible());
     }
 
     @Test
@@ -710,11 +711,11 @@ class ObjectionServiceTest {
 
         when(oracleQueryClient.getCompanyActionCode(COMPANY_NUMBER)).thenReturn(ACTION_CODE_INELIGIBLE);
         doThrow(new ValidationException(INELIGIBLE_COMPANY_STRUCK_OFF)).when(actionCodeValidator).validate(ACTION_CODE_INELIGIBLE, REQUEST_ID);
-        boolean response = objectionService.isCompanyEligible(COMPANY_NUMBER, REQUEST_ID);
+        ObjectionEligibility response = objectionService.isCompanyEligible(COMPANY_NUMBER, REQUEST_ID);
 
         verify(oracleQueryClient).getCompanyActionCode(COMPANY_NUMBER);
         verify(actionCodeValidator).validate(ACTION_CODE_INELIGIBLE, REQUEST_ID);
 
-        assertFalse(response);
+        assertFalse(response.isEligible());
     }
 }


### PR DESCRIPTION
Added endpoint and new eligibility object as per slack discussion. Unit tested but have yet to get it working due to required changes in the interceptors which are still causing problems. At present nothing is calling this endpoint - anything introduced that does will need to be feature flagged while the interceptor problem is being handled.

As the error is triggered on the endpoint call and not reaching the code the feature flag cannot be added here.

The interceptor work will be completed on another ticket - although only one line needs to be changed there will be side effects of such a change and they will need to be handled as well.