### PR TITLE
OBJ-322 Removing use of ObjectionStatus in company eligible check

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/eligibility/ObjectionEligibility.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/eligibility/ObjectionEligibility.java
@@ -7,11 +7,11 @@ public class ObjectionEligibility {
     @JsonProperty("is_eligible")
     private boolean isEligible;
 
-    public boolean isEligible() {
-        return isEligible;
+    public ObjectionEligibility(boolean isEligible) {
+        this.isEligible = isEligible;
     }
 
-    public void setEligible(boolean eligible) {
-        isEligible = eligible;
+    public boolean isEligible() {
+        return isEligible;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
@@ -124,27 +124,35 @@ public class ObjectionService implements IObjectionService {
     private ObjectionStatus getObjectionStatusForCreate(Long actionCode, String companyNumber, String logContext) {
         ObjectionStatus objectionStatus = ObjectionStatus.OPEN;
         try {
-            actionCodeValidator.validate(actionCode, logContext);
+            validateActionCode(actionCode, companyNumber, logContext);
         } catch (ValidationException validationException) {
             objectionStatus = validationException.getStatus();
-
-            Map<String, Object> logMap = buildLogMap(companyNumber, null, null);
-            logMap.put(LogConstants.ACTION_CODE.getValue(), actionCode);
-            logMap.put(LogConstants.OBJECTION_STATUS.getValue(), objectionStatus);
-            logger.infoContext(logContext, "Action Code validation failed", logMap);
         }
         return objectionStatus;
     }
 
     public ObjectionEligibility isCompanyEligible(String companyNumber, String requestId) {
+        Long actionCode = getActionCode(companyNumber, requestId);
+
         boolean isCompanyEligible = true;
         try {
-            Long actionCode = getActionCode(companyNumber, requestId);
-            actionCodeValidator.validate(actionCode, requestId);
+            validateActionCode(actionCode, companyNumber, requestId);
         } catch (ValidationException validationException) {
             isCompanyEligible = false;
         }
         return new ObjectionEligibility(isCompanyEligible);
+    }
+
+    private void validateActionCode(Long actionCode, String companyNumber, String logContext) throws ValidationException {
+        try {
+            actionCodeValidator.validate(actionCode, logContext);
+        } catch (ValidationException validationException) {
+            Map<String, Object> logMap = buildLogMap(companyNumber, null, null);
+            logMap.put(LogConstants.ACTION_CODE.getValue(), actionCode);
+            logMap.put(LogConstants.OBJECTION_STATUS.getValue(), validationException.getStatus());
+            logger.infoContext(logContext, "Action Code validation failed", logMap);
+            throw validationException;
+        }
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
@@ -137,12 +137,14 @@ public class ObjectionService implements IObjectionService {
     }
 
     public ObjectionEligibility isCompanyEligible(String companyNumber, String requestId) {
-        Long actionCode = getActionCode(companyNumber, requestId);
-        final ObjectionStatus objectionStatus = getObjectionStatusForCreate(actionCode, companyNumber, requestId);
-
-        ObjectionEligibility objectionEligibility = new ObjectionEligibility();
-        objectionEligibility.setEligible(!objectionStatus.isIneligible());
-        return objectionEligibility;
+        boolean isCompanyEligible = true;
+        try {
+            Long actionCode = getActionCode(companyNumber, requestId);
+            actionCodeValidator.validate(actionCode, requestId);
+        } catch (ValidationException validationException) {
+            isCompanyEligible = false;
+        }
+        return new ObjectionEligibility(isCompanyEligible);
     }
 
     /**

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.api.strikeoffobjections.controller;
 
+import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -573,8 +574,7 @@ class ObjectionControllerTest {
 
     @Test
     void isCompanyEligibleForObjectionTestTrueReturned() {
-        ObjectionEligibility objectionEligibility = new ObjectionEligibility();
-        objectionEligibility.setEligible(true);
+        ObjectionEligibility objectionEligibility = new ObjectionEligibility(true);
         when(objectionService.isCompanyEligible(COMPANY_NUMBER, REQUEST_ID)).thenReturn(objectionEligibility);
         ResponseEntity<ObjectionEligibility> responseEntity = objectionController.isCompanyEligibleForObjection(COMPANY_NUMBER, REQUEST_ID);
         assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
@@ -583,12 +583,19 @@ class ObjectionControllerTest {
 
     @Test
     void isCompanyEligibleForObjectionTestFalseReturned() {
-        ObjectionEligibility objectionEligibility = new ObjectionEligibility();
-        objectionEligibility.setEligible(false);
+        ObjectionEligibility objectionEligibility = new ObjectionEligibility(false);
         when(objectionService.isCompanyEligible(COMPANY_NUMBER, REQUEST_ID)).thenReturn(objectionEligibility);
         ResponseEntity<ObjectionEligibility> responseEntity = objectionController.isCompanyEligibleForObjection(COMPANY_NUMBER, REQUEST_ID);
         assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
         assertFalse(responseEntity.getBody().isEligible());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            System.out.println(objectMapper.writeValueAsString(objectionEligibility));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/controller/ObjectionControllerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.api.strikeoffobjections.controller;
 
-import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -588,14 +587,5 @@ class ObjectionControllerTest {
         ResponseEntity<ObjectionEligibility> responseEntity = objectionController.isCompanyEligibleForObjection(COMPANY_NUMBER, REQUEST_ID);
         assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
         assertFalse(responseEntity.getBody().isEligible());
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        try {
-            System.out.println(objectMapper.writeValueAsString(objectionEligibility));
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-
     }
-
 }


### PR DESCRIPTION
Changing company eligible check to just use the actionCodeValidator and remove the need for converting to an ObjectionStatus to get the result.
Refactoring calls to actionCodeValidator so we only have to log the action code once