### PR TITLE
OBJ-20 Adding feature flag for sending chips contact data

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequest.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequest.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.api.strikeoffobjections.model.chips;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang.StringUtils;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
@@ -11,6 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ChipsRequest {
 
     @JsonProperty("objection_id")

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsService.java
@@ -15,6 +15,9 @@ public class ChipsService implements IChipsService {
     @Value("${EMAIL_ATTACHMENT_DOWNLOAD_URL_PREFIX}")
     private String attachmentDownloadUrlPrefix;
 
+    @Value("${FEATURE_FLAG_SEND_CHIPS_CONTACT_DATA}")
+    private boolean isFeatureFlagSendChipsContactDataEnabled;
+
     private final ChipsClient chipsClient;
 
     @Autowired
@@ -27,13 +30,21 @@ public class ChipsService implements IChipsService {
         ChipsRequest chipsRequest = new ChipsRequest(
                 objection.getId(),
                 objection.getCompanyNumber(),
-                objection.getAttachments(),
-                objection.getId(), // TODO OBJ-162 add ref number
-                objection.getCreatedBy().getEmail(),
-                objection.getReason(),
-                attachmentDownloadUrlPrefix
+                getAsContactDataOrNull(objection.getAttachments()),
+                getAsContactDataOrNull(objection.getId()), // TODO OBJ-162 add ref number
+                getAsContactDataOrNull(objection.getCreatedBy().getEmail()),
+                getAsContactDataOrNull(objection.getReason()),
+                getAsContactDataOrNull(attachmentDownloadUrlPrefix)
         );
 
         this.chipsClient.sendToChips(requestId, chipsRequest);
+    }
+
+    private <T> T getAsContactDataOrNull(T data) {
+        if (isFeatureFlagSendChipsContactDataEnabled) {
+            return data;
+        } else {
+            return null;
+        }
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
@@ -1,5 +1,8 @@
 package uk.gov.companieshouse.api.strikeoffobjections.model.chips;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Attachment;
 import uk.gov.companieshouse.api.strikeoffobjections.utils.Utils;
@@ -8,7 +11,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 class ChipsRequestTest {
@@ -101,5 +106,29 @@ class ChipsRequestTest {
         String actualOutput = chipsRequest.toString();
 
         assertEquals(expectedOutput, actualOutput);
+    }
+
+    @Test
+    void testNullsIgnoredWhenConvertingChipsRequestToJson() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        ChipsRequest chipsRequest = new ChipsRequest(
+                OBJECTION_ID,
+                COMPANY_NUMBER,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        String chipsRequestAsJsonString = mapper.writeValueAsString(chipsRequest);
+
+        assertTrue(chipsRequestAsJsonString.contains("objection_id"));
+        assertTrue(chipsRequestAsJsonString.contains("company_number"));
+        assertFalse(chipsRequestAsJsonString.contains("attachments"));
+        assertFalse(chipsRequestAsJsonString.contains("reference_number"));
+        assertFalse(chipsRequestAsJsonString.contains("customer_email"));
+        assertFalse(chipsRequestAsJsonString.contains("reason"));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.api.strikeoffobjections.model.chips;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -111,7 +110,6 @@ class ChipsRequestTest {
     @Test
     void testNullsIgnoredWhenConvertingChipsRequestToJson() throws JsonProcessingException {
         ObjectMapper mapper = new ObjectMapper();
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         ChipsRequest chipsRequest = new ChipsRequest(
                 OBJECTION_ID,
                 COMPANY_NUMBER,

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsServiceTest.java
@@ -6,14 +6,10 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -51,7 +47,7 @@ class ChipsServiceTest {
     @Test
     void testSendingToChipsCreatesCorrectRequestWithContactFeatureFlagOn() {
         ReflectionTestUtils.setField(chipsService, "attachmentDownloadUrlPrefix", DOWNLOAD_URL_PREFIX);
-        ReflectionTestUtils.setField(chipsService, "isFeatureFlagSendChipsContactEnabled", true);
+        ReflectionTestUtils.setField(chipsService, "isFeatureFlagSendChipsContactDataEnabled", true);
 
         Objection objection = Utils.getTestObjection(
                 OBJECTION_ID, REASON, COMPANY_NUMBER, USER_ID, EMAIL, LOCAL_DATE_TIME,
@@ -82,7 +78,7 @@ class ChipsServiceTest {
     @Test
     void testSendingToChipsCreatesCorrectRequestWithContactFeatureFlagOff() {
         ReflectionTestUtils.setField(chipsService, "attachmentDownloadUrlPrefix", DOWNLOAD_URL_PREFIX);
-        ReflectionTestUtils.setField(chipsService, "isFeatureFlagSendChipsContactEnabled", false);
+        ReflectionTestUtils.setField(chipsService, "isFeatureFlagSendChipsContactDataEnabled", false);
 
         Objection objection = Utils.getTestObjection(
                 OBJECTION_ID, REASON, COMPANY_NUMBER, USER_ID, EMAIL, LOCAL_DATE_TIME,


### PR DESCRIPTION
Adding new feature flag to allow us to not send the contact data to chips if chips code to handle it is not deployed.
The flag being set to true will mean that nulls get set in the ChipsRequest which has been updated to ignore null fields when converting to json.