### PR TITLE
obj-356 Updated model to include name and share identity

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequest.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequest.java
@@ -27,6 +27,12 @@ public class ChipsRequest {
     @JsonProperty("reference_number")
     private final String referenceNumber;
 
+    @JsonProperty("full_name")
+    private String fullName;
+
+    @JsonProperty("share_identity")
+    private Boolean shareIdentity;
+
     @JsonProperty("customer_email")
     private final String customerEmail;
 
@@ -37,6 +43,8 @@ public class ChipsRequest {
                         String companyNumber,
                         List<Attachment> attachments,
                         String referenceNumber,
+                        String fullName,
+                        Boolean shareIdentity,
                         String customerEmail,
                         String reason,
                         String downloadPrefix) {
@@ -44,6 +52,8 @@ public class ChipsRequest {
         this.companyNumber = companyNumber;
         this.attachments = buildAttachmentsMap(downloadPrefix, attachments);
         this.referenceNumber = referenceNumber;
+        this.fullName = fullName;
+        this.shareIdentity = shareIdentity;
         this.customerEmail = customerEmail;
         this.reason = reason;
     }
@@ -62,6 +72,14 @@ public class ChipsRequest {
 
     public String getReferenceNumber() {
         return referenceNumber;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public Boolean isShareIdentity() {
+        return shareIdentity;
     }
 
     public String getCustomerEmail() {
@@ -98,6 +116,8 @@ public class ChipsRequest {
             ",companyNumber='" + companyNumber + '\'' +
             ",attachments='" + getAttachmentsAsString() + '\'' +
             ",referenceNumber='" + referenceNumber + '\'' +
+            ",fullName='" + fullName + '\'' +
+            ",shareIdentity='" + shareIdentity + '\'' +
             ",customerEmail='" + customerEmail + '\'' +
             ",reason='" + reason + '\'' +
             "}";

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsService.java
@@ -32,6 +32,8 @@ public class ChipsService implements IChipsService {
                 objection.getCompanyNumber(),
                 getAsContactDataOrNull(objection.getAttachments()),
                 getAsContactDataOrNull(objection.getId()), // TODO OBJ-162 add ref number
+                getAsContactDataOrNull(objection.getCreatedBy().getFullName()),
+                getAsContactDataOrNull(objection.getCreatedBy().isShareIdentity()),
                 getAsContactDataOrNull(objection.getCreatedBy().getEmail()),
                 getAsContactDataOrNull(objection.getReason()),
                 getAsContactDataOrNull(attachmentDownloadUrlPrefix)

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/chips/ChipsClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/chips/ChipsClientTest.java
@@ -29,6 +29,8 @@ class ChipsClientTest {
     private static final String OBJECTION_ID = "OBJECTION_ID";
     private static final String COMPANY_NUMBER = "12345678";
     private static final List<Attachment> ATTACHMENTS = new ArrayList<>();
+    private static final String FULL_NAME = "Joe Bloggs";
+    private static final Boolean SHARE_IDENTITY = true;
     private static final String CUSTOMER_EMAIL = "test123@ch.gov.uk";
     private static final String REASON = "This is a test";
     private static final String CHIPS_REST_URL = "test.url";
@@ -52,6 +54,8 @@ class ChipsClientTest {
                 COMPANY_NUMBER,
                 ATTACHMENTS,
                 OBJECTION_ID,
+                FULL_NAME,
+                SHARE_IDENTITY,
                 CUSTOMER_EMAIL,
                 REASON,
                 DOWNLOAD_URL_PREFIX

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/model/chips/ChipsRequestTest.java
@@ -20,6 +20,8 @@ class ChipsRequestTest {
     private static final String OBJECTION_ID = "test123";
     private static final String COMPANY_NUMBER = "12345678";
     private static final List<Attachment> ATTACHMENTS = new ArrayList<>();
+    private static final String FULL_NAME = "Joe Bloggs";
+    private static final Boolean SHARE_IDENTITY = true;
     private static final String CUSTOMER_EMAIL = "test123@ch.gov.uk";
     private static final String REASON = "This is a test";
     private static final String DOWNLOAD_URL_PREFIX = "http://chs-test-web:4000/strike-off-objections/download";
@@ -32,6 +34,8 @@ class ChipsRequestTest {
                 COMPANY_NUMBER,
                 ATTACHMENTS,
                 OBJECTION_ID,
+                FULL_NAME,
+                SHARE_IDENTITY,
                 CUSTOMER_EMAIL,
                 REASON,
                 DOWNLOAD_URL_PREFIX
@@ -43,6 +47,8 @@ class ChipsRequestTest {
         assertEquals(String.format("%s/url2/download", DOWNLOAD_URL_PREFIX),
                 chipsRequest.getAttachments().get("TestAttachment2"));
         assertEquals(OBJECTION_ID, chipsRequest.getReferenceNumber());
+        assertEquals(FULL_NAME, chipsRequest.getFullName());
+        assertEquals(SHARE_IDENTITY, chipsRequest.isShareIdentity());
         assertEquals(CUSTOMER_EMAIL, chipsRequest.getCustomerEmail());
         assertEquals(REASON, chipsRequest.getReason());
     }
@@ -54,6 +60,8 @@ class ChipsRequestTest {
                 COMPANY_NUMBER,
                 null,
                 OBJECTION_ID,
+                FULL_NAME,
+                SHARE_IDENTITY,
                 CUSTOMER_EMAIL,
                 REASON,
                 DOWNLOAD_URL_PREFIX
@@ -68,7 +76,8 @@ class ChipsRequestTest {
         String expectedOutput = "ChipsRequest{objectionId='test123',companyNumber='12345678'," +
                 "attachments='{TestAttachment2=http://chs-test-web:4000/strike-off-objections/download/url2/download, " +
                 "TestAttachment1=http://chs-test-web:4000/strike-off-objections/download/url1/download}'," +
-                "referenceNumber='test123',customerEmail='test123@ch.gov.uk',reason='This is a test'}";
+                "referenceNumber='test123',fullName='Joe Bloggs',shareIdentity='true'," +
+                "customerEmail='test123@ch.gov.uk',reason='This is a test'}";
 
         Utils.setTestAttachmentsWithLinks(ATTACHMENTS);
         ChipsRequest chipsRequest = new ChipsRequest(
@@ -76,6 +85,8 @@ class ChipsRequestTest {
                 COMPANY_NUMBER,
                 ATTACHMENTS,
                 OBJECTION_ID,
+                FULL_NAME,
+                SHARE_IDENTITY,
                 CUSTOMER_EMAIL,
                 REASON,
                 DOWNLOAD_URL_PREFIX
@@ -89,7 +100,8 @@ class ChipsRequestTest {
     @Test
     void testToStringNullAttachments() {
         String expectedOutput = "ChipsRequest{objectionId='test123',companyNumber='12345678',attachments=''," +
-                "referenceNumber='test123',customerEmail='test123@ch.gov.uk',reason='This is a test'}";
+                "referenceNumber='test123',fullName='Joe Bloggs',shareIdentity='true'," +
+                "customerEmail='test123@ch.gov.uk',reason='This is a test'}";
 
         Utils.setTestAttachmentsWithLinks(ATTACHMENTS);
         ChipsRequest chipsRequest = new ChipsRequest(
@@ -97,6 +109,8 @@ class ChipsRequestTest {
                 COMPANY_NUMBER,
                 null,
                 OBJECTION_ID,
+                FULL_NAME,
+                SHARE_IDENTITY,
                 CUSTOMER_EMAIL,
                 REASON,
                 DOWNLOAD_URL_PREFIX
@@ -117,6 +131,8 @@ class ChipsRequestTest {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null
         );
 
@@ -126,6 +142,8 @@ class ChipsRequestTest {
         assertTrue(chipsRequestAsJsonString.contains("company_number"));
         assertFalse(chipsRequestAsJsonString.contains("attachments"));
         assertFalse(chipsRequestAsJsonString.contains("reference_number"));
+        assertFalse(chipsRequestAsJsonString.contains("full_name"));
+        assertFalse(chipsRequestAsJsonString.contains("share_identity"));
         assertFalse(chipsRequestAsJsonString.contains("customer_email"));
         assertFalse(chipsRequestAsJsonString.contains("reason"));
     }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ChipsServiceTest.java
@@ -33,6 +33,8 @@ class ChipsServiceTest {
     private static final String OBJECTION_ID = "OBJECTION_ID";
     private static final String COMPANY_NUMBER = "COMPANY_NUMBER";
     private static final LocalDateTime LOCAL_DATE_TIME = LocalDateTime.of(2020, 12, 10, 8, 0);
+    private static final String FULL_NAME = "Joe Bloggs";
+    private static final Boolean SHARE_IDENTITY = false;
     private static final String EMAIL = "demo@ch.gov.uk";
     private static final String USER_ID = "32324";
     private static final String REASON = "THIS IS A REASON";
@@ -51,7 +53,7 @@ class ChipsServiceTest {
 
         Objection objection = Utils.getTestObjection(
                 OBJECTION_ID, REASON, COMPANY_NUMBER, USER_ID, EMAIL, LOCAL_DATE_TIME,
-                Utils.buildTestObjectionCreate("Joe Bloggs", false));
+                Utils.buildTestObjectionCreate(FULL_NAME, SHARE_IDENTITY));
         List<Attachment> attachments = new ArrayList<>();
         Utils.setTestAttachmentsWithLinks(attachments);
         objection.setAttachments(attachments);
@@ -66,6 +68,8 @@ class ChipsServiceTest {
         assertEquals(COMPANY_NUMBER, chipsRequest.getCompanyNumber());
         assertEquals(OBJECTION_ID, chipsRequest.getObjectionId());
         assertEquals(OBJECTION_ID, chipsRequest.getReferenceNumber());
+        assertEquals(FULL_NAME, chipsRequest.getFullName());
+        assertEquals(SHARE_IDENTITY, chipsRequest.isShareIdentity());
         assertEquals(EMAIL, chipsRequest.getCustomerEmail());
         assertEquals(REASON, chipsRequest.getReason());
 
@@ -82,7 +86,7 @@ class ChipsServiceTest {
 
         Objection objection = Utils.getTestObjection(
                 OBJECTION_ID, REASON, COMPANY_NUMBER, USER_ID, EMAIL, LOCAL_DATE_TIME,
-                Utils.buildTestObjectionCreate("Joe Bloggs", false));
+                Utils.buildTestObjectionCreate(FULL_NAME, SHARE_IDENTITY));
         objection.setAttachments(new ArrayList<>());
 
         chipsService.sendObjection(REQUEST_ID, objection);
@@ -95,6 +99,8 @@ class ChipsServiceTest {
         assertEquals(COMPANY_NUMBER, chipsRequest.getCompanyNumber());
         assertEquals(OBJECTION_ID, chipsRequest.getObjectionId());
         assertNull(chipsRequest.getReferenceNumber());
+        assertNull(chipsRequest.getFullName());
+        assertNull(chipsRequest.isShareIdentity());
         assertNull(chipsRequest.getCustomerEmail());
         assertNull(chipsRequest.getReason());
         assertNull(chipsRequest.getAttachments());


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/OBJ-356

Updated the ChipsRequest model  and service with full name and share identity.

Updated the chips service, request and client unit tests to include the two new fields.