### PR TITLE
OBJ-210 Clone map passed to structured logging to stop duplicate message

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/common/ApiLogger.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/common/ApiLogger.java
@@ -5,10 +5,13 @@ import uk.gov.companieshouse.api.strikeoffobjections.Application;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Acts as a wrapper for the structured logger to help with unit testing
+ * Acts as a wrapper for the structured logger to help with unit testing and also ensures that the
+ * map data structure passed to the Companies House logger is not changed if used by subsequent
+ * logging calls.
  */
 @Component
 public class ApiLogger {
@@ -20,7 +23,7 @@ public class ApiLogger {
     }
 
     public void debugContext(String context, String message, Map<String, Object> dataMap) {
-        LOGGER.debugContext(context, message, dataMap);
+        LOGGER.debugContext(context, message, cloneMapData(dataMap));
     }
 
     public void info(String message) {
@@ -32,7 +35,7 @@ public class ApiLogger {
     }
 
     public void infoContext(String context, String message, Map<String, Object> dataMap) {
-        LOGGER.infoContext(context, message, dataMap);
+        LOGGER.infoContext(context, message, cloneMapData(dataMap));
     }
 
     public void errorContext(String context, Exception e) {
@@ -44,6 +47,22 @@ public class ApiLogger {
     }
 
     public void errorContext(String context, String message, Exception e, Map<String, Object> dataMap) {
-        LOGGER.errorContext(context, message, e, dataMap);
+        LOGGER.errorContext(context, message, e, cloneMapData(dataMap));
+    }
+
+    /**
+     * The Companies House logging implementation modifies the data map content which means that
+     * if the same data map is used for subsequent calls any new message that might be passed in
+     * is not displayed in certain log format outputs. Creating a clone of the data map gets around
+     * this issue.
+     *  
+     * @param dataMap The map data to log
+     * @return A cloned copy of the map data
+     */
+    private Map<String, Object> cloneMapData(Map<String, Object> dataMap) {
+        Map<String, Object> clonedMapData = new HashMap<>();
+        clonedMapData.putAll(dataMap);
+
+        return clonedMapData;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/common/ApiLoggerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/common/ApiLoggerTest.java
@@ -1,0 +1,59 @@
+package uk.gov.companieshouse.api.strikeoffobjections.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import uk.gov.companieshouse.api.strikeoffobjections.groups.Unit;
+
+@Unit
+@ExtendWith(MockitoExtension.class)
+public class ApiLoggerTest {
+
+    private static final String CONTEXT = "CONTEXT";
+    private static final String TEST_MESSAGE = "TEST";
+    private static final String LOG_MAP_KEY = "COMPANY_NUMBER";
+    private static final String LOG_MAP_VALUE = "00006400";
+    
+    @InjectMocks
+    private static ApiLogger apiLogger;
+    
+    private Map<String, Object> logMap;
+
+    @BeforeEach
+    public void setup() {
+        logMap = new HashMap<>();
+        logMap.put(LOG_MAP_KEY, LOG_MAP_VALUE);
+    }
+
+    @Test
+    public void testDebugContextLoggingDoesNotModifyLogMap() {
+        apiLogger.debugContext(CONTEXT, TEST_MESSAGE, logMap);
+        
+        assertEquals(1, logMap.size());
+        assertEquals(LOG_MAP_VALUE, logMap.get(LOG_MAP_KEY));
+    }
+
+    @Test
+    public void testInfoContextLoggingDoesNotModifyLogMap() {
+        apiLogger.infoContext(CONTEXT, TEST_MESSAGE, logMap);
+        
+        assertEquals(1, logMap.size());
+        assertEquals(LOG_MAP_VALUE, logMap.get(LOG_MAP_KEY));
+    }
+
+    @Test
+    public void testErrorContextLoggingDoesNotModifyLogMap() {
+        apiLogger.errorContext(CONTEXT, TEST_MESSAGE, new Exception("TEST"), logMap);
+
+        assertEquals(1, logMap.size());
+        assertEquals(LOG_MAP_VALUE, logMap.get(LOG_MAP_KEY));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/common/ApiLoggerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/common/ApiLoggerTest.java
@@ -15,7 +15,7 @@ import uk.gov.companieshouse.api.strikeoffobjections.groups.Unit;
 
 @Unit
 @ExtendWith(MockitoExtension.class)
-public class ApiLoggerTest {
+class ApiLoggerTest {
 
     private static final String CONTEXT = "CONTEXT";
     private static final String TEST_MESSAGE = "TEST";
@@ -28,13 +28,13 @@ public class ApiLoggerTest {
     private Map<String, Object> logMap;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         logMap = new HashMap<>();
         logMap.put(LOG_MAP_KEY, LOG_MAP_VALUE);
     }
 
     @Test
-    public void testDebugContextLoggingDoesNotModifyLogMap() {
+    void testDebugContextLoggingDoesNotModifyLogMap() {
         apiLogger.debugContext(CONTEXT, TEST_MESSAGE, logMap);
         
         assertEquals(1, logMap.size());
@@ -42,7 +42,7 @@ public class ApiLoggerTest {
     }
 
     @Test
-    public void testInfoContextLoggingDoesNotModifyLogMap() {
+    void testInfoContextLoggingDoesNotModifyLogMap() {
         apiLogger.infoContext(CONTEXT, TEST_MESSAGE, logMap);
         
         assertEquals(1, logMap.size());
@@ -50,7 +50,7 @@ public class ApiLoggerTest {
     }
 
     @Test
-    public void testErrorContextLoggingDoesNotModifyLogMap() {
+    void testErrorContextLoggingDoesNotModifyLogMap() {
         apiLogger.errorContext(CONTEXT, TEST_MESSAGE, new Exception("TEST"), logMap);
 
         assertEquals(1, logMap.size());


### PR DESCRIPTION
This will result in correct messages in the TEST and LIVE logs, e.g.

```
{"created":"2020-10-21T14:03:14.555Z","event":"info","namespace":"strike-off-objections-api","context":"PNHxpd7o4hnhw_O3FCgFMR7uIJG2","data":{"message":"GET /{objectionId} request received","company_number":"05916434","objection_id":"5f903f9e938cb425e88c81f0"}}
{"created":"2020-10-21T14:03:14.602Z","event":"info","namespace":"strike-off-objections-api","context":"PNHxpd7o4hnhw_O3FCgFMR7uIJG2","data":{"message":"Finished GET /{objectionId} request","company_number":"05916434","objection_id":"5f903f9e938cb425e88c81f0"}}
```

As opposed to output with duplicate messages:

```
{"created":"2020-10-21T14:03:14.555Z","event":"info","namespace":"strike-off-objections-api","context":"PNHxpd7o4hnhw_O3FCgFMR7uIJG2","data":{"message":"GET /{objectionId} request received","company_number":"05916434","objection_id":"5f903f9e938cb425e88c81f0"}}
{"created":"2020-10-21T14:03:14.602Z","event":"info","namespace":"strike-off-objections-api","context":"PNHxpd7o4hnhw_O3FCgFMR7uIJG2","data":{"message":"GET /{objectionId} request received","company_number":"05916434","objection_id":"5f903f9e938cb425e88c81f0"}}
```