### PR TITLE
OBJ-397 cannot download attachment of processed objection

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/config/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/config/InterceptorConfig.java
@@ -69,14 +69,14 @@ public class InterceptorConfig implements WebMvcConfigurer {
                 .excludePathPatterns(ELIGIBILITY_CHECK_PATH)
                 .order(1);
 
-        registry.addInterceptor(companyNumberInterceptor(logger))
-                .addPathPatterns(STRIKE_OFF_OBJECTIONS_OBJECTION_ID)
-                .excludePathPatterns(ELIGIBILITY_CHECK_PATH)
-                .order(2);
-
         registry.addInterceptor(objectionStatusInterceptor(logger))
                 .addPathPatterns(STRIKE_OFF_OBJECTIONS_OBJECTION_ID)
                 .excludePathPatterns(ELIGIBILITY_CHECK_PATH, ATTACHMENTS_DOWNLOAD_PATH)
+                .order(2);
+
+        registry.addInterceptor(companyNumberInterceptor(logger))
+                .addPathPatterns(STRIKE_OFF_OBJECTIONS_OBJECTION_ID)
+                .excludePathPatterns(ELIGIBILITY_CHECK_PATH)
                 .order(3);
 
         registry.addInterceptor(userAuthorizationInterceptor(logger, ericHeaderParser))

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/CompanyNumberInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/CompanyNumberInterceptor.java
@@ -32,7 +32,7 @@ public class CompanyNumberInterceptor implements HandlerInterceptor {
         final boolean companyNumberMatches = doCompanyNumbersMatch(companyNumber, objection);
 
         if (!companyNumberMatches) {
-            apiLogger.errorContext(requestId, "Provided company number does not match objection company number", null);
+            apiLogger.infoContext(requestId, "Provided company number does not match objection company number");
             response.setStatus(HttpStatus.BAD_REQUEST.value());
         }
 

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/CompanyNumberInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/CompanyNumberInterceptor.java
@@ -32,7 +32,7 @@ public class CompanyNumberInterceptor implements HandlerInterceptor {
         final boolean companyNumberMatches = doCompanyNumbersMatch(companyNumber, objection);
 
         if (!companyNumberMatches) {
-            apiLogger.debugContext(requestId, "Provided company number does not match objection company number");
+            apiLogger.errorContext(requestId, "Provided company number does not match objection company number", null);
             response.setStatus(HttpStatus.BAD_REQUEST.value());
         }
 

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/ObjectionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/ObjectionInterceptor.java
@@ -6,7 +6,6 @@ import org.springframework.web.servlet.HandlerMapping;
 import uk.gov.companieshouse.api.strikeoffobjections.common.ApiLogger;
 import uk.gov.companieshouse.api.strikeoffobjections.exception.ObjectionNotFoundException;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
-import uk.gov.companieshouse.api.strikeoffobjections.model.entity.ObjectionStatus;
 import uk.gov.companieshouse.api.strikeoffobjections.service.IObjectionService;
 import uk.gov.companieshouse.api.strikeoffobjections.service.impl.ERICHeaderFields;
 
@@ -17,7 +16,6 @@ import java.util.Map;
 public class ObjectionInterceptor implements HandlerInterceptor {
 
     private static final String OBJECTION_NOT_FOUND = "Objection not found";
-    private static final String OBJECTION_STATUS_INVALID = "Objection is not in a valid state for this operation. Expected a status of OPEN but was %s";
 
     private final IObjectionService objectionService;
     private final ApiLogger apiLogger;
@@ -37,20 +35,6 @@ public class ObjectionInterceptor implements HandlerInterceptor {
 
         try {
             Objection objection = objectionService.getObjection(requestId, objectionId);
-            
-            // Operations on objections via the API REST interface are only allowed whilst the objection is
-            // still 'open', i.e. has not yet been submitted (to CHIPS) for processing
-            if (ObjectionStatus.OPEN != objection.getStatus()) {
-                apiLogger.errorContext(
-                        requestId,
-                        String.format(OBJECTION_STATUS_INVALID, objection.getStatus()),
-                        null
-                );
-
-                response.setStatus(HttpStatus.FORBIDDEN.value());
-                return false;
-            }
-            
             request.setAttribute(InterceptorConstants.OBJECTION_ATTRIBUTE, objection);
         } catch (ObjectionNotFoundException e) {
             apiLogger.errorContext(

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/ObjectionStatusInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/ObjectionStatusInterceptor.java
@@ -1,0 +1,43 @@
+package uk.gov.companieshouse.api.strikeoffobjections.interceptor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.HandlerInterceptor;
+import uk.gov.companieshouse.api.strikeoffobjections.common.ApiLogger;
+import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
+import uk.gov.companieshouse.api.strikeoffobjections.model.entity.ObjectionStatus;
+import uk.gov.companieshouse.api.strikeoffobjections.service.impl.ERICHeaderFields;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class ObjectionStatusInterceptor implements HandlerInterceptor {
+
+    private static final String OBJECTION_STATUS_INVALID = "Objection is not in a valid state for this operation. Expected a status of OPEN but was %s";
+
+    private final ApiLogger apiLogger;
+
+    public ObjectionStatusInterceptor(ApiLogger apiLogger) {
+        this.apiLogger = apiLogger;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        final String requestId = request.getHeader(ERICHeaderFields.ERIC_REQUEST_ID);
+        apiLogger.debugContext(requestId, "Checking provided company number matches objection company number");
+        final Objection objection = (Objection) request.getAttribute(InterceptorConstants.OBJECTION_ATTRIBUTE);
+
+        // Operations on objections via the API REST interface are only allowed whilst the objection is
+        // still 'open', i.e. has not yet been submitted (to CHIPS) for processing
+        if (ObjectionStatus.OPEN != objection.getStatus()) {
+            apiLogger.errorContext(
+                    requestId,
+                    String.format(OBJECTION_STATUS_INVALID, objection.getStatus()),
+                    null
+            );
+
+            response.setStatus(HttpStatus.FORBIDDEN.value());
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/ObjectionStatusInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/ObjectionStatusInterceptor.java
@@ -29,10 +29,9 @@ public class ObjectionStatusInterceptor implements HandlerInterceptor {
         // Operations on objections via the API REST interface are only allowed whilst the objection is
         // still 'open', i.e. has not yet been submitted (to CHIPS) for processing
         if (ObjectionStatus.OPEN != objection.getStatus()) {
-            apiLogger.errorContext(
+            apiLogger.infoContext(
                     requestId,
-                    String.format(OBJECTION_STATUS_INVALID, objection.getStatus()),
-                    null
+                    String.format(OBJECTION_STATUS_INVALID, objection.getStatus())
             );
 
             response.setStatus(HttpStatus.FORBIDDEN.value());

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/authorization/AttachmentDownloadAuthorizationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/authorization/AttachmentDownloadAuthorizationInterceptor.java
@@ -39,7 +39,7 @@ public class AttachmentDownloadAuthorizationInterceptor extends HandlerIntercept
             return true;
         }
 
-        logger.errorContext(requestId, "User is not authorized to download the attachment", null);
+        logger.infoContext(requestId, "User is not authorized to download the attachment");
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
 
         return false;

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/authorization/AttachmentDownloadAuthorizationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/authorization/AttachmentDownloadAuthorizationInterceptor.java
@@ -39,7 +39,7 @@ public class AttachmentDownloadAuthorizationInterceptor extends HandlerIntercept
             return true;
         }
 
-        logger.debugContext(requestId, "User is not authorized to download the attachment");
+        logger.errorContext(requestId, "User is not authorized to download the attachment", null);
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
 
         return false;

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/authorization/UserAuthorizationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/authorization/UserAuthorizationInterceptor.java
@@ -38,7 +38,7 @@ public class UserAuthorizationInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        apiLogger.debugContext(requestId, "User not authorised to access objection");
+        apiLogger.errorContext(requestId, "User not authorised to access objection", null);
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
         return false;
     }

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/authorization/UserAuthorizationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/authorization/UserAuthorizationInterceptor.java
@@ -38,7 +38,7 @@ public class UserAuthorizationInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        apiLogger.errorContext(requestId, "User not authorised to access objection", null);
+        apiLogger.infoContext(requestId, "User not authorised to access objection");
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
         return false;
     }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/config/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/config/InterceptorConfigTest.java
@@ -1,0 +1,95 @@
+package uk.gov.companieshouse.api.strikeoffobjections.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import uk.gov.companieshouse.api.strikeoffobjections.common.ApiLogger;
+import uk.gov.companieshouse.api.strikeoffobjections.groups.Unit;
+import uk.gov.companieshouse.api.strikeoffobjections.interceptor.CompanyNumberInterceptor;
+import uk.gov.companieshouse.api.strikeoffobjections.interceptor.ObjectionInterceptor;
+import uk.gov.companieshouse.api.strikeoffobjections.interceptor.ObjectionStatusInterceptor;
+import uk.gov.companieshouse.api.strikeoffobjections.interceptor.authorization.AttachmentDownloadAuthorizationInterceptor;
+import uk.gov.companieshouse.api.strikeoffobjections.interceptor.authorization.UserAuthorizationInterceptor;
+import uk.gov.companieshouse.api.strikeoffobjections.service.IObjectionService;
+import uk.gov.companieshouse.api.strikeoffobjections.service.impl.ERICHeaderParser;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.spy;
+
+@Unit
+@ExtendWith(MockitoExtension.class)
+class InterceptorConfigTest {
+
+    @Mock
+    private ApiLogger apiLogger;
+
+    @Mock
+    private IObjectionService objectionService;
+
+    @Mock
+    private ERICHeaderParser ericHeaderParser;
+
+    @InjectMocks
+    private InterceptorConfig interceptorConfig;
+
+    @Test
+    void testAttachmentDownloadAuthInterceptorCreation() {
+        AttachmentDownloadAuthorizationInterceptor interceptor =
+                interceptorConfig.attachmentDownloadAuthorizationInterceptor(apiLogger);
+
+        assertNotNull(interceptor);
+    }
+
+    @Test
+    void testUserAuthorizationInterceptorCreation() {
+        UserAuthorizationInterceptor interceptor =
+                interceptorConfig.userAuthorizationInterceptor(apiLogger, ericHeaderParser);
+
+        assertNotNull(interceptor);
+    }
+
+    @Test
+    void testCompanyNumberInterceptorCreation() {
+        CompanyNumberInterceptor interceptor =
+                interceptorConfig.companyNumberInterceptor(apiLogger);
+
+        assertNotNull(interceptor);
+    }
+
+    @Test
+    void testObjectionInterceptorCreation() {
+        ObjectionInterceptor interceptor =
+                interceptorConfig.objectionInterceptor(objectionService, apiLogger);
+
+        assertNotNull(interceptor);
+    }
+
+    @Test
+    void testObjectionStatusInterceptorCreation() {
+        ObjectionStatusInterceptor interceptor =
+                interceptorConfig.objectionStatusInterceptor(apiLogger);
+
+        assertNotNull(interceptor);
+    }
+
+    @Test
+    void testAddInterceptors() {
+        InterceptorRegistry interceptorRegistry = new InterceptorRegistry();
+        InterceptorRegistry spyRegistry = spy(interceptorRegistry);
+
+        interceptorConfig.addInterceptors(spyRegistry);
+
+        InOrder interceptorOrder  = inOrder(spyRegistry);
+        interceptorOrder.verify(spyRegistry).addInterceptor(any(AttachmentDownloadAuthorizationInterceptor.class));
+        interceptorOrder.verify(spyRegistry).addInterceptor(any(ObjectionInterceptor.class));
+        interceptorOrder.verify(spyRegistry).addInterceptor(any(ObjectionStatusInterceptor.class));
+        interceptorOrder.verify(spyRegistry).addInterceptor(any(CompanyNumberInterceptor.class));
+        interceptorOrder.verify(spyRegistry).addInterceptor(any(UserAuthorizationInterceptor.class));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/ObjectionInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/ObjectionInterceptorTest.java
@@ -78,17 +78,4 @@ class ObjectionInterceptorTest {
         assertFalse(result);
         verify(response, times(1)).setStatus(HttpStatus.NOT_FOUND.value());
     }
-
-    @Test
-    void testObjectionInterceptorObjectionNoLongerOpen() throws Exception{
-        Objection objection = new Objection();
-        objection.setStatus(ObjectionStatus.PROCESSED);
-
-        when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(PATH_VARIABLES);
-        when(objectionService.getObjection(any(), any())).thenReturn(objection);
-
-        boolean result = objectionInterceptor.preHandle(request, response, null);
-        assertFalse(result);
-        verify(response, times(1)).setStatus(HttpStatus.FORBIDDEN.value());
-    }
 }

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/ObjectionStatusInterceptorIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/ObjectionStatusInterceptorIntegrationTest.java
@@ -77,7 +77,7 @@ class ObjectionStatusInterceptorIntegrationTest {
         when(objectionService.getObjection(any(), any())).thenReturn(getObjection(ObjectionStatus.SUBMITTED));
 
         RequestBuilder requestBuilder = MockMvcRequestBuilders
-                .get("/company/00006400/strike-off-objections/5f05c3f24be29647ef076f21")
+                .get("/company/00000099/strike-off-objections/5f05c3f24be29647ef076f21")
                 .accept(MediaType.APPLICATION_JSON)
                 .header("X-Request-Id", "444");
 

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/ObjectionStatusInterceptorIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/ObjectionStatusInterceptorIntegrationTest.java
@@ -17,7 +17,6 @@ import uk.gov.companieshouse.api.strikeoffobjections.common.ApiLogger;
 import uk.gov.companieshouse.api.strikeoffobjections.controller.AttachmentMapper;
 import uk.gov.companieshouse.api.strikeoffobjections.controller.ObjectionController;
 import uk.gov.companieshouse.api.strikeoffobjections.controller.ObjectionMapper;
-import uk.gov.companieshouse.api.strikeoffobjections.exception.ObjectionNotFoundException;
 import uk.gov.companieshouse.api.strikeoffobjections.groups.Integration;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.CreatedBy;
 import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
@@ -33,7 +32,7 @@ import static org.mockito.Mockito.when;
 @Integration
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(value = { ObjectionController.class })
-class ObjectionInterceptorIntegrationTest {
+class ObjectionStatusInterceptorIntegrationTest {
     @Autowired
     private MockMvc mockMvc;
 
@@ -56,7 +55,7 @@ class ObjectionInterceptorIntegrationTest {
     private PluggableResponseEntityFactory responseEntityFactory;
 
     @BeforeEach
-    public void setup() throws ObjectionNotFoundException {
+    void setup() {
         when(headerParser.getEmailAddress(any())).thenReturn("demo@ch.gov.uk");
     }
 
@@ -78,7 +77,7 @@ class ObjectionInterceptorIntegrationTest {
         when(objectionService.getObjection(any(), any())).thenReturn(getObjection(ObjectionStatus.SUBMITTED));
 
         RequestBuilder requestBuilder = MockMvcRequestBuilders
-                .get("/company/00000099/strike-off-objections/5f05c3f24be29647ef076f21")
+                .get("/company/00006400/strike-off-objections/5f05c3f24be29647ef076f21")
                 .accept(MediaType.APPLICATION_JSON)
                 .header("X-Request-Id", "444");
 

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/ObjectionStatusInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/ObjectionStatusInterceptorTest.java
@@ -1,0 +1,67 @@
+package uk.gov.companieshouse.api.strikeoffobjections.interceptor;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import uk.gov.companieshouse.api.strikeoffobjections.common.ApiLogger;
+import uk.gov.companieshouse.api.strikeoffobjections.groups.Unit;
+import uk.gov.companieshouse.api.strikeoffobjections.model.entity.Objection;
+import uk.gov.companieshouse.api.strikeoffobjections.model.entity.ObjectionStatus;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@Unit
+@ExtendWith(MockitoExtension.class)
+class ObjectionStatusInterceptorTest {
+
+    private static final String OBJECTION_ATTRIBUTE = "objection";
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private ApiLogger apiLogger;
+
+    @InjectMocks
+    private ObjectionStatusInterceptor objectionStatusInterceptor;
+
+    @Test
+    void testObjectionInterceptorObjectionNoLongerOpen() throws Exception {
+        Objection objection = new Objection();
+        objection.setStatus(ObjectionStatus.PROCESSED);
+
+        when(request.getAttribute(OBJECTION_ATTRIBUTE)).thenReturn(objection);
+
+        boolean result = objectionStatusInterceptor.preHandle(request, response, null);
+
+        assertFalse(result);
+        verify(response, times(1)).setStatus(HttpStatus.FORBIDDEN.value());
+    }
+
+    @Test
+    void testObjectionInterceptorObjectionOpen() throws Exception {
+        Objection objection = new Objection();
+        objection.setStatus(ObjectionStatus.OPEN);
+
+        when(request.getAttribute(OBJECTION_ATTRIBUTE)).thenReturn(objection);
+
+        boolean result = objectionStatusInterceptor.preHandle(request, response, null);
+
+        assertTrue(result);
+        verifyNoInteractions(response);
+    }
+}


### PR DESCRIPTION
The Objection Status check in ObjectionInterceptor was blocking downloads due to the objection status not being OPEN.
I've extracted the status check into it's own interceptor to give us greater control over how we apply it.
We can now exclude the download path from the status check.  