### PR TITLE
OBJ-408 move company profile call during processing

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/processor/ObjectionProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/processor/ObjectionProcessor.java
@@ -81,9 +81,9 @@ public class ObjectionProcessor {
         
         validateObjectionData(objection, httpRequestId);
 
-        sendObjectionToChips(objection, httpRequestId);
-
         CompanyProfileApi companyProfile = this.companyProfileService.getCompanyProfile(objection.getCompanyNumber(), httpRequestId);
+
+        sendObjectionToChips(objection, httpRequestId);
 
         sendInternalEmail(objection, companyProfile, httpRequestId);
 

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/processor/ObjectionProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/processor/ObjectionProcessorTest.java
@@ -299,7 +299,7 @@ class ObjectionProcessorTest {
     }
 
     @Test
-    void processHandlesChipsUncheckedException() throws ServiceException {
+    void processHandlesChipsUncheckedException() {
         Objection dummyObjection = Utils.getTestObjection(
                 OBJECTION_ID, REASON, COMPANY_NUMBER, USER_ID, EMAIL, LOCAL_DATE_TIME,
                 Utils.buildTestObjectionCreate(FULL_NAME, false));


### PR DESCRIPTION
Moving call to get company profile before sending chips data during processing to prevent half processed cases if company profile api is unavailable.