### PR TITLE
OBJ-413 Make api accept objections with empty reason text

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/entity/Objection.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/model/entity/Objection.java
@@ -204,8 +204,7 @@ public class Objection {
     }
 
     public boolean isDataEnteredByUserIncomplete() {
-        return StringUtils.isEmpty(reason)
-                || StringUtils.isEmpty(createdBy.getFullName())
+        return StringUtils.isEmpty(createdBy.getFullName())
                 || attachments.isEmpty();
     }
 

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/processor/ObjectionProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/processor/ObjectionProcessorTest.java
@@ -129,13 +129,20 @@ class ObjectionProcessorTest {
     }
 
     @Test
-    void processThrowsServiceExceptionIfUserDataIsMissingReason() {
+    void processShouldNotThrowServiceExceptionIfUserDataIsMissingReason() throws Exception {
+        when(companyProfileService.getCompanyProfile(COMPANY_NUMBER, HTTP_REQUEST_ID))
+                .thenReturn(Utils.getDummyCompanyProfile(COMPANY_NUMBER, JURISDICTION));
         Objection dummyObjection = Utils.getTestObjection(
-                OBJECTION_ID, "", COMPANY_NUMBER, USER_ID, EMAIL, LOCAL_DATE_TIME,
+                OBJECTION_ID, REASON, COMPANY_NUMBER, USER_ID, EMAIL, LOCAL_DATE_TIME,
                 Utils.buildTestObjectionCreate(FULL_NAME, false));
         dummyObjection.setStatus(ObjectionStatus.SUBMITTED);
 
-        processObjectionAndCheckForError(dummyObjection);
+        ArgumentCaptor<Objection> objectionArgumentCaptor = ArgumentCaptor.forClass(Objection.class);
+        assertDoesNotThrow(() -> objectionProcessor.process(dummyObjection, HTTP_REQUEST_ID));
+        verify(objectionRepository, times(1)).save(objectionArgumentCaptor.capture());
+
+        Objection objection = objectionArgumentCaptor.getValue();
+        assertEquals(ObjectionStatus.PROCESSED, objection.getStatus());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/processor/ObjectionProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/processor/ObjectionProcessorTest.java
@@ -133,7 +133,7 @@ class ObjectionProcessorTest {
         when(companyProfileService.getCompanyProfile(COMPANY_NUMBER, HTTP_REQUEST_ID))
                 .thenReturn(Utils.getDummyCompanyProfile(COMPANY_NUMBER, JURISDICTION));
         Objection dummyObjection = Utils.getTestObjection(
-                OBJECTION_ID, REASON, COMPANY_NUMBER, USER_ID, EMAIL, LOCAL_DATE_TIME,
+                OBJECTION_ID, "", COMPANY_NUMBER, USER_ID, EMAIL, LOCAL_DATE_TIME,
                 Utils.buildTestObjectionCreate(FULL_NAME, false));
         dummyObjection.setStatus(ObjectionStatus.SUBMITTED);
 


### PR DESCRIPTION
Removing a reason text check to allow objections with empty reasons to be processed.