### PR TITLE
Log message data not message

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/chips/ChipsKafkaClient.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/chips/ChipsKafkaClient.java
@@ -67,7 +67,7 @@ public class ChipsKafkaClient implements ChipsSender {
             logger.infoContext(requestId, logMessageSendText, dataForInfoLogMessage);
 
             Map<String, Object> dataForDebugLogMessage = new HashMap<>(dataForInfoLogMessage);
-            dataForDebugLogMessage.put("message_contents", chipsRestInterfacesSend);
+            dataForDebugLogMessage.put("message_contents", chipsRestInterfacesSend.getData());
             logger.debugContext(requestId, logMessageSendText, dataForDebugLogMessage);
 
             Message message = new Message();

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/chips/ChipsKafkaClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/chips/ChipsKafkaClientTest.java
@@ -172,7 +172,7 @@ class ChipsKafkaClientTest {
         logMap = logMapArgumentCaptor.getValue();
         assertEquals(CHIPS_REST_INTERFACES_SEND_TOPIC, logMap.get(topicKey));
         assertTrue(StringUtils.isNotBlank((String)logMap.get(messageIdKey)));
-        assertEquals(chipsRestInterfacesSend, logMap.get(messageContentsKey));
+        assertEquals(chipsRestInterfacesSend.getData(), logMap.get(messageContentsKey));
 
         verify(logger, times(1)).infoContext(eq(REQUEST_ID), eq(finishedSendingLogMessage), logMapArgumentCaptor.capture());
 


### PR DESCRIPTION
Logger is unable to convert ChipsRestInterfacesSend into JSON causing the log to not work.
Logging out ChipsRestInterfaceSend.data instead should work