### PR TITLE
OBJ-475 Removing lookup of external schema for ChipsKafkaClient as no …

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/chips/ChipsKafkaClient.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/chips/ChipsKafkaClient.java
@@ -3,10 +3,8 @@ package uk.gov.companieshouse.api.strikeoffobjections.chips;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import org.apache.avro.Schema;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.strikeoffobjections.Application;
@@ -36,10 +34,6 @@ public class ChipsKafkaClient implements ChipsSender {
 
     @Autowired
     private AvroSerializer avroSerializer;
-
-    @Autowired
-    @Qualifier("chips-rest-interfaces-send")
-    private Schema schema;
 
     @Value("${CHIPS_REST_INTERFACES_SEND_TOPIC}")
     private String chipsRestInterfacesSendTopic;

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/config/KafkaConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/config/KafkaConfiguration.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.api.strikeoffobjections.config;
 import org.apache.avro.Schema;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,22 +21,12 @@ public class KafkaConfiguration {
     @Value("${EMAIL_SCHEMA_URI}")
     private String emailSchemaUri;
 
-    @Value("${CHIPS_REST_INTERFACES_SEND_SCHEMA_URI}")
-    private String chipsRestInterfacesSendSchemaUri;
-
     @Value("${KAFKA_PRODUCER_MAXIMUM_RETRY_ATTEMPTS}")
     private String maximumRetryAttempts;
 
     @Bean
-    @Qualifier("email-send")
     public Schema fetchSchema(KafkaRestClient restClient) throws JSONException {
        return getSchema(restClient, emailSchemaUri);
-    }
-
-    @Bean
-    @Qualifier("chips-rest-interfaces-send")
-    public Schema fetchChipsRestInterfacesSendSchema(KafkaRestClient restClient) throws JSONException {
-        return getSchema(restClient, chipsRestInterfacesSendSchemaUri);
     }
 
     private Schema getSchema(KafkaRestClient restClient, String schemaUri) throws JSONException {

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/email/KafkaEmailClient.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/email/KafkaEmailClient.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.api.strikeoffobjections.email;
 import org.apache.avro.Schema;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.strikeoffobjections.common.AvroSerializer;
@@ -30,7 +29,7 @@ public class KafkaEmailClient {
     @Autowired
     public KafkaEmailClient(CHKafkaProducer producer,
                             AvroSerializer avroSerializer,
-                            @Qualifier("email-send") Schema schema) {
+                            Schema schema) {
         this.producer = producer;
         this.avroSerializer = avroSerializer;
         this.schema = schema;

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/chips/ChipsKafkaClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/chips/ChipsKafkaClientTest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.api.strikeoffobjections.chips;
 
-import org.apache.avro.Schema;
 import org.apache.commons.lang.StringUtils;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,9 +66,6 @@ class ChipsKafkaClientTest {
 
     @Mock
     private AvroSerializer avroSerializer;
-
-    @Mock
-    private Schema schema;
 
     @Mock
     private ApiLogger logger;


### PR DESCRIPTION
…longer needed

the app fails to start in ci-dev as it tries to lookup the schema but it is not registered in that env yet. As it turns out, it is not needed anyway as we get the schema from the model kafka class so removed the schema lookup for ChipsKafkaClient