### PR TITLE
Bump log4j-to-slf4j from 2.15.0 to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-to-slf4j</artifactId>
-                <version>2.15.0</version>
+                <version>2.16.0</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Bump log4j-to-slf4j from 2.15.0 to 2.16.0

Resolves part of [DEBT-1507](https://companieshouse.atlassian.net/browse/DEBT-1507)