### PR TITLE
Addressed the vulnerabilities present in the current version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,8 @@ sonar:
 .PHONY: sonar-pr-analysis
 sonar-pr-analysis:
 	mvn sonar:sonar -P sonar-pr-analysis
+
+.PHONY: security-check
+security-check:
+	mvn org.owasp:dependency-check-maven:update-only
+	mvn org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=4 -DassemblyAnalyzerEnabled=false

--- a/pom.xml
+++ b/pom.xml
@@ -18,25 +18,31 @@
 
     <properties>
         <java.version>21</java.version>
-        <structured-logging.version>3.0.1</structured-logging.version>
-        <rest-service-common-library.version>2.0.1</rest-service-common-library.version>
-        <avro.version>1.11.3</avro.version>
-        <ch-kafka.version>3.0.1</ch-kafka.version>
-        <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
         <spring-boot-version>3.2.1</spring-boot-version>
         <spring-boot-maven-plugin.version>3.2.1</spring-boot-maven-plugin.version>
-        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-        <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
+        <avro.version>1.11.3</avro.version>
+        <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
-        <kafka-models.version>3.0.4</kafka-models.version>
-        <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
         <log4j.version>2.21.1</log4j.version>
-        <junit-jupiter.version>5.10.0</junit-jupiter.version>
-        <mockito.version>5.4.0</mockito.version>
-        <api-sdk-java.version>4.2.5</api-sdk-java.version>
-        <api-sdk-manager-java-library.version>3.0.3</api-sdk-manager-java-library.version>
+        <jackson-databind.version>2.16.1</jackson-databind.version>
+
+        <structured-logging.version>3.0.1</structured-logging.version>
+        <rest-service-common-library.version>2.0.2</rest-service-common-library.version>
+        <ch-kafka.version>3.0.1</ch-kafka.version>
+        <api-sdk-java.version>6.0.7</api-sdk-java.version>
+        <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
+        <kafka-models.version>3.0.6</kafka-models.version>
+
         <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
         <jib-maven-plugin.version>3.4.0</jib-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+        <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
+        <pitest-junit5-plugin.version>1.2.1</pitest-junit5-plugin.version>
+
+        <mockito.version>5.4.0</mockito.version>
+        <junit-jupiter.version>5.10.0</junit-jupiter.version>
+        <pitest.version>1.15.3</pitest.version>
     </properties>
 
     <dependencyManagement>
@@ -134,11 +140,25 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>rest-service-common-library</artifactId>
             <version>${rest-service-common-library.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson-databind.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>api-sdk-manager-java-library</artifactId>
@@ -177,7 +197,7 @@
         <dependency>
             <groupId>org.pitest</groupId>
             <artifactId>pitest-parent</artifactId>
-            <version>1.15.3</version>
+            <version>${pitest.version}</version>
             <type>pom</type>
         </dependency>
     </dependencies>
@@ -254,7 +274,7 @@
             <plugin>
                 <groupId>org.pitest</groupId>
                 <artifactId>pitest-maven</artifactId>
-                <version>1.15.2</version>
+                <version>${pitest.version}</version>
                 <configuration>
                     <testStrengthThreshold>78</testStrengthThreshold>
                     <coverageThreshold>69</coverageThreshold>
@@ -264,7 +284,7 @@
                     <dependency>
                         <groupId>org.pitest</groupId>
                         <artifactId>pitest-junit5-plugin</artifactId>
-                        <version>1.2.1</version>
+                        <version>${pitest-junit5-plugin.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/suppress.xml
+++ b/suppress.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+The following suppressions are required due to the Sonar
+plugin not having a patch available to address the CVEs
+-->
+
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+   file name: sonar-scanner-api-2.16.3.1081.jar (shaded: com.squareup.okio:okio:1.17.2)
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.squareup\.okio/okio@.*$</packageUrl>
+        <cve>CVE-2023-3635</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: sonar-scanner-api-2.16.3.1081.jar (shaded: com.squareup.okhttp3:okhttp:3.14.2)
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.squareup\.okhttp3/okhttp@.*$</packageUrl>
+        <cve>CVE-2023-0833</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: sonar-scanner-api-2.16.3.1081.jar (shaded: com.squareup.okhttp3:okhttp-urlconnection:3.14.2)
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.squareup\.okhttp3/okhttp\-urlconnection@.*$</packageUrl>
+        <cve>CVE-2023-0833</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: plexus-sec-dispatcher-2.0.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-sec\-dispatcher@.*$</packageUrl>
+        <cve>CVE-2022-4245</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: sonar-scanner-api-2.16.3.1081.jar (shaded: com.squareup.okhttp3:okhttp:3.14.2)
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.squareup\.okhttp3/okhttp@.*$</packageUrl>
+        <vulnerabilityName>CVE-2021-0341</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: plexus-sec-dispatcher-2.0.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-sec\-dispatcher@.*$</packageUrl>
+        <cve>CVE-2022-4244</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: plexus-cipher-2.0.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-cipher@.*$</packageUrl>
+        <cve>CVE-2022-4245</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: plexus-cipher-2.0.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-cipher@.*$</packageUrl>
+        <cve>CVE-2022-4244</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: json-path-2.8.0.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.jayway\.jsonpath/json\-path@.*$</packageUrl>
+        <cve>CVE-2023-51074</cve>
+    </suppress>
+</suppressions>


### PR DESCRIPTION
5 libraries were updated to latest to remove the reported vulnerabilities:
 * rest-service-common-library
 * ch-kafka
 * api-sdk-java
 * api-sdk-manager-java-library
 * kafka-models

Added supressions due to the Sonar plugin not yet having a patched release available

CC-1098