### PR TITLE
Add third lb for internalapi, used by web service

### DIFF
--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -51,6 +51,15 @@ data "aws_lb_listener" "secondary_lb_listener" {
   port = 443
 }
 
+data "aws_lb" "third_lb" {
+  name = "${var.environment}-chs-internalapi"
+}
+
+data "aws_lb_listener" "third_lb_listener" {
+  load_balancer_arn = data.aws_lb.third_lb.arn
+  port = 443
+}
+
 # retrieve all secrets for this stack using the stack path
 data "aws_ssm_parameters_by_path" "secrets" {
   path = "/${local.name_prefix}"

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -38,6 +38,10 @@ module "ecs-service" {
           listener_arn           = data.aws_lb_listener.secondary_lb_listener.arn,
           load_balancer_arn      = data.aws_lb.secondary_lb.arn
       }
+      "internal-api-lb": {
+          listener_arn           = data.aws_lb_listener.third_lb_listener.arn,
+          load_balancer_arn      = data.aws_lb.third_lb.arn
+      }
   } 
 
   # ECS Task container health check


### PR DESCRIPTION
Add third load balancer route path to strike-off-objections-api:

https://github.com/companieshouse/strike-off-objections-web/blob/master/src/modules/sdk/objections/service.ts#L17

