### PR TITLE
fix: Downgraded kafka-clients to `2.3.1` due to compatibility issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,18 @@
 ### Overview
 API for handling objections to a company being struck off the register
 
-### Requirements
+| :exclamation:  To ensure communication to the Kafka Broker isn't broken The Kafka-clients dependency is included |
+|------------------------------------------------------------------------------------------------------------------|
 
+``` xml
+    <dependency>
+        <groupId>org.apache.kafka</groupId>
+        <artifactId>kafka-clients</artifactId>
+        <version>2.3.1</version>
+    </dependency> 
+```
+### Requirements
+ 
 In order to run the service locally you will need the following:
 
 - [OpenJDK 21](https://jdk.java.net/21/)
@@ -70,8 +80,11 @@ This is common to all the endpoints.
 | `GAZ_1_ACTION_CODE`                              | 5000                                                  | As above notice given, but not struck off objections allowed.                             |
 | `HUMAN_LOG`                                      | 1                                                     |                                                                                           |
 | `KAFKA_BROKER_ADDR`                              | `kafka:9092`                                          |                                                                                           |
-| `MONGODB_URL`                                    | `mongodb://mongo`                                     |                                                                                           |
+| `MONGODB_URL`                                    | `mongodb://mongo/strike_off_objections`               |                                                                                           |
 | `ORACLE_QUERY_API_URL`                           | `http://oracle-query-api:8080`                        | Company lookup.                                                                           |
 | `SCHEMA_REGISTRY_URL`                            | `http://chs-kafka-schemas`                            | Where email schema is stored.                                                             |
 | `UPLOAD_MAX_FILE_SIZE`                           | 6MB                                                   |                                                                                           |
 | `UPLOAD_MAX_REQUEST_SIZE`                        | 6MB                                                   |                                                                                           |
+| `FEATURE_FLAG_USE_KAFKA_FOR_CHIPS_CALL_170121`   | false                                                 |                                                                                           |
+| `PAYMENTS_API_URL`                               | http://api.chs.local:4001                             |                                                                                           |
+| `DOCUMENT_API_LOCAL_URL`                         | 'NOT-USEDNOT-USED'                                    |                                                                                           |

--- a/pom.xml
+++ b/pom.xml
@@ -18,34 +18,30 @@
 
     <properties>
         <java.version>21</java.version>
-        <spring-boot-version>3.2.2</spring-boot-version>
-        <spring-boot-maven-plugin.version>3.2.2</spring-boot-maven-plugin.version>
+        <spring-boot-version>3.2.3</spring-boot-version>
+        <spring-boot-maven-plugin.version>3.2.3</spring-boot-maven-plugin.version>
         <avro.version>1.11.3</avro.version>
         <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
         <log4j.version>2.21.1</log4j.version>
         <jackson-databind.version>2.16.1</jackson-databind.version>
 
-        <structured-logging.version>3.0.1</structured-logging.version>
-        <rest-service-common-library.version>2.0.2</rest-service-common-library.version>
-        <ch-kafka.version>3.0.1</ch-kafka.version>
-        <api-sdk-java.version>6.0.7</api-sdk-java.version>
+        <structured-logging.version>3.0.3</structured-logging.version>
         <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
         <kafka-models.version>3.0.6</kafka-models.version>
+        <kafka-clients.version>2.3.1</kafka-clients.version>
         <rest-service-common-library.version>2.0.2</rest-service-common-library.version>
         <ch-kafka.version>3.0.1</ch-kafka.version>
-        <api-sdk-java.version>6.0.7</api-sdk-java.version>
-        <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
-        <kafka-models.version>3.0.6</kafka-models.version>
+        <api-sdk-java.version>6.0.14</api-sdk-java.version>
         <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
-        <jib-maven-plugin.version>3.4.0</jib-maven-plugin.version>
+        <jib-maven-plugin.version>3.4.1</jib-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
-        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-        <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
+        <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
+        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <pitest-junit5-plugin.version>1.2.1</pitest-junit5-plugin.version>
 
         <junit-jupiter.version>5.10.0</junit-jupiter.version>
-        <pitest.version>1.15.3</pitest.version>
+        <pitest.version>1.15.8</pitest.version>
         <mockito.version>5.4.0</mockito.version>
     </properties>
 
@@ -119,6 +115,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
             <version>${spring-boot-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>            
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -167,7 +169,18 @@
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>api-sdk-manager-java-library</artifactId>
             <version>${api-sdk-manager-java-library.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>kafka-clients</artifactId>
+                </exclusion>           
+            </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka-clients.version}</version>
+        </dependency>        
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>api-sdk-java</artifactId>
@@ -177,12 +190,28 @@
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>kafka-models</artifactId>
             <version>${kafka-models.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>kafka-clients</artifactId>
+                </exclusion>                
+            </exclusions>            
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>ch-kafka</artifactId>
             <version>${ch-kafka.version}</version>
-        </dependency>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>kafka-clients</artifactId>
+                </exclusion>
+            </exclusions>            
+        </dependency>        
         <dependency>
             <groupId>org.sonarsource.scanner.maven</groupId>
             <artifactId>sonar-maven-plugin</artifactId>
@@ -269,7 +298,12 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <version>${jib-maven-plugin.version}</version>
                 <configuration>
-                    <from><image>amazoncorretto:21</image></from>
+                    <from>
+                        <image>416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-corretto-build-21:latest</image>
+                    </from>
+                    <to>
+                        <image>416670754337.dkr.ecr.eu-west-2.amazonaws.com/strike-off-objections-api:latest</image>
+                    </to>
                     <container>
                         <expandClasspathDependencies>true</expandClasspathDependencies>
                     </container>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <pitest-junit5-plugin.version>1.2.1</pitest-junit5-plugin.version>
 
         <junit-jupiter.version>5.10.0</junit-jupiter.version>
-        <pitest.version>1.15.8</pitest.version>
+        <pitest.version>1.15.3</pitest.version>
         <mockito.version>5.4.0</mockito.version>
     </properties>
 

--- a/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/chips/ChipsKafkaClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/strikeoffobjections/chips/ChipsKafkaClientTest.java
@@ -1,5 +1,25 @@
 package uk.gov.companieshouse.api.strikeoffobjections.chips;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.function.Supplier;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
@@ -12,6 +32,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+
 import uk.gov.companieshouse.api.strikeoffobjections.Application;
 import uk.gov.companieshouse.api.strikeoffobjections.common.ApiLogger;
 import uk.gov.companieshouse.api.strikeoffobjections.common.AvroSerializer;
@@ -23,26 +44,6 @@ import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 import uk.gov.companieshouse.kafka.message.Message;
 import uk.gov.companieshouse.kafka.producer.CHKafkaProducer;
 import uk.gov.companieshouse.service.ServiceException;
-
-import java.io.IOException;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.function.Supplier;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @Unit
 @ExtendWith(MockitoExtension.class)
@@ -100,7 +101,7 @@ class ChipsKafkaClientTest {
         when(dateTimeSupplier.get()).thenReturn(DATE_TIME);
 
         TopicPartition topicPartition = new TopicPartition("test",1);
-        recordMetadata = new RecordMetadata(topicPartition, 0,0,0,0, 0);
+        recordMetadata = new RecordMetadata(topicPartition, 0, 0, 0, TIMESTAMP, 0, 0);
     }
 
     @Test

--- a/suppress.xml
+++ b/suppress.xml
@@ -6,6 +6,7 @@ plugin not having a patch available to address the CVEs
 -->
 
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+<!-- These are needed for due version of sonar scanner being used (a newer version doesn't exist yet) -->
     <suppress>
         <notes><![CDATA[
    file name: sonar-scanner-api-2.16.3.1081.jar (shaded: com.squareup.okio:okio:1.17.2)
@@ -69,4 +70,77 @@ plugin not having a patch available to address the CVEs
         <packageUrl regex="true">^pkg:maven/com\.jayway\.jsonpath/json\-path@.*$</packageUrl>
         <cve>CVE-2023-51074</cve>
     </suppress>
+
+<!-- These are needed because of the version of kafka-clients we use for compatibility reasons  -->
+ <suppress>
+   <notes><![CDATA[
+   file name: snappy-java-1.1.7.3.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.xerial\.snappy/snappy\-java@.*$</packageUrl>
+   <cve>CVE-2023-43642</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: snappy-java-1.1.7.3.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.xerial\.snappy/snappy\-java@.*$</packageUrl>
+   <cve>CVE-2023-34455</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: snappy-java-1.1.7.3.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.xerial\.snappy/snappy\-java@.*$</packageUrl>
+   <cve>CVE-2023-34454</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: snappy-java-1.1.7.3.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.xerial\.snappy/snappy\-java@.*$</packageUrl>
+   <cve>CVE-2023-34453</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: kafka-clients-2.3.1.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.apache\.kafka/kafka\-clients@.*$</packageUrl>
+   <cve>CVE-2021-38153</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: kafka-clients-2.3.1.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.apache\.kafka/kafka\-clients@.*$</packageUrl>
+   <vulnerabilityName>CVE-2023-25194</vulnerabilityName>
+</suppress>
+
+<!-- These are needed because the version of commons-compress within kafka-models is out of date-->
+<suppress>
+   <notes><![CDATA[
+   file name: commons-compress-1.24.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons\-compress@.*$</packageUrl>
+   <cve>CVE-2024-26308</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: commons-compress-1.24.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons\-compress@.*$</packageUrl>
+   <cve>CVE-2024-25710</cve>
+</suppress> 
+<suppress>
+   <notes><![CDATA[
+   file name: http2-common-11.0.19.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.http2/http2\-common@.*$</packageUrl>
+   <vulnerabilityName>CVE-2024-22201</vulnerabilityName>
+</suppress><suppress>
+   <notes><![CDATA[
+   file name: http2-common-11.0.19.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.http2/http2\-common@.*$</packageUrl>
+   <vulnerabilityName>CVE-2024-22201</vulnerabilityName>
+</suppress>
 </suppressions>


### PR DESCRIPTION
  * Updated a number of libraries to the latest versions to remove some vulnerabilities
  * Due to downgrading kaka clients new CVE supressions were added

  doc: README.md
    * Added three mandatory fields top the table
    * Recorded the fact that kafka-clients needs to be explicitly added as a dependency

CC-1212