### PR TITLE
Rollback to previous version of kafka-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <structured-logging.version>3.0.3</structured-logging.version>
         <api-sdk-manager-java-library.version>3.0.7</api-sdk-manager-java-library.version>
         <kafka-models.version>3.0.6</kafka-models.version>
-        <kafka-clients.version>3.7.1</kafka-clients.version>
+        <kafka-clients.version>2.3.1</kafka-clients.version>
         <rest-service-common-library.version>2.0.2</rest-service-common-library.version>
         <ch-kafka.version>3.0.2</ch-kafka.version>
         <private-api-sdk-java.version>4.0.292</private-api-sdk-java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <structured-logging.version>3.0.3</structured-logging.version>
         <api-sdk-manager-java-library.version>3.0.7</api-sdk-manager-java-library.version>
         <kafka-models.version>3.0.6</kafka-models.version>
-        <kafka-clients.version>2.3.1</kafka-clients.version>
+        <kafka-clients.version>2.6.3</kafka-clients.version>
         <rest-service-common-library.version>2.0.2</rest-service-common-library.version>
         <ch-kafka.version>3.0.2</ch-kafka.version>
         <private-api-sdk-java.version>4.0.292</private-api-sdk-java.version>


### PR DESCRIPTION
Rolling back kafka-client to previous version.

This was updated to version 3.7.1 in this PR: https://github.com/companieshouse/strike-off-objections-api/pull/167

We started getting this issue in the dev environments after bumping up the version. 

<img width="1728" alt="Screenshot 2025-06-12 at 12 44 37" src="https://github.com/user-attachments/assets/2ccdfe5c-d803-40f0-ba3b-5c1484f82691" />

On debugging further we came across this PR which exclusively sets the kafka-client version to an older one due to compatibility issues. 

https://github.com/companieshouse/strike-off-objections-api/pull/158