### PR TITLE
KAF-236: Terraform fix

### DIFF
--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -63,13 +63,14 @@ locals {
 
   ssm_service_version_map = [
     for sec in module.secrets.secrets : {
-      "name" = "${replace(upper(local.service_name), "-", "_")}_${var.ssm_version_prefix}${replace(upper(basename(sec.name)), "-", "_")}",
-      "value" = tostring(sec.version)
+      name = "${replace(upper(local.service_name), "-", "_")}_${var.ssm_version_prefix}${replace(upper(basename(sec.name)), "-", "_")}", value = sec.version
     }
   ]
 
   # secrets to go in list
   task_secrets = concat(local.service_secret_list,local.global_secret_list,[])
 
-  task_environment = concat(local.ssm_global_version_map,local.ssm_service_version_map)
+  task_environment = concat(local.ssm_global_version_map,local.ssm_service_version_map,[
+    { "name" : "PORT", "value" : local.container_port }
+  ])
 }

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -82,10 +82,9 @@ module "ecs-service" {
 }
 
 module "secrets" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.365"
+  source = "git@github.com:companieshouse/terraform-modules//aws/parameter-store?ref=1.0.365"
 
   name_prefix = "${local.service_name}-${var.environment}"
-  environment = var.environment
   kms_key_id  = data.aws_kms_key.kms_key.id
   secrets     = nonsensitive(local.service_secrets)
 }


### PR DESCRIPTION
* Secrets path moved to parameter store
* `task_environment` syntax fixed