### PR TITLE
Fix critical vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <kafka-clients.version>4.2.0</kafka-clients.version>
         <rest-service-common-library.version>2.0.14</rest-service-common-library.version>
         <ch-kafka.version>3.0.15</ch-kafka.version>
-        <private-api-sdk-java.version>6.0.33</private-api-sdk-java.version>
+        <private-api-sdk-java.version>7.0.9</private-api-sdk-java.version>
         <jib-maven-plugin.version>3.5.1</jib-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
         <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
@@ -87,6 +87,12 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <!-- Temporary managed transitive dependency remove once migrated to spring-boot.version 4 -->
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>3.2.0</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,31 +13,28 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.12</version>
+        <version>2.1.14</version>
         <relativePath/>
     </parent>
     <properties>
         <java.version>21</java.version>
-        <spring-boot-version>3.5.11</spring-boot-version>
+        <spring-boot.version>3.5.16</spring-boot.version>
         <spring-boot-maven-plugin.version>3.5.9</spring-boot-maven-plugin.version>
         <avro.version>1.11.5</avro.version>
         <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
-        <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
-        <log4j.version>2.21.1</log4j.version>
-        <jackson-databind.version>2.16.2</jackson-databind.version>
-        <structured-logging.version>3.0.51</structured-logging.version>
-        <api-sdk-manager-java-library.version>3.0.14</api-sdk-manager-java-library.version>
-        <kafka-models.version>3.0.26</kafka-models.version>
+        <log4j.version>2.25.4</log4j.version>
+        <structured-logging.version>3.0.57</structured-logging.version>
+        <api-sdk-manager-java-library.version>3.0.25</api-sdk-manager-java-library.version>
+        <kafka-models.version>3.0.35</kafka-models.version>
         <kafka-clients.version>4.2.0</kafka-clients.version>
-        <rest-service-common-library.version>2.0.9</rest-service-common-library.version>
-        <ch-kafka.version>3.0.6</ch-kafka.version>
-        <private-api-sdk-java.version>4.0.431</private-api-sdk-java.version>
+        <rest-service-common-library.version>2.0.14</rest-service-common-library.version>
+        <ch-kafka.version>3.0.15</ch-kafka.version>
+        <private-api-sdk-java.version>7.0.4</private-api-sdk-java.version>
         <jib-maven-plugin.version>3.5.1</jib-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
         <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.5.4</maven-failsafe-plugin.version>
-        <jackson-core-version>2.18.6</jackson-core-version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <org-json.version>20231013</org-json.version>
 
@@ -55,19 +52,7 @@
     </properties>
     <dependencyManagement>
         <dependencies>
-            <!-- start fixes to vulnerable transitive dependencies-->
-            <!-- CVE-2025-68161(6.3) -->
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-api</artifactId>
-                <version>2.25.3</version>
-            </dependency>
-            <!-- end fixes to vulnerable transitive dependencies -->
-            <dependency>
-                <groupId>jakarta.annotation</groupId>
-                <artifactId>jakarta.annotation-api</artifactId>
-                <version>${jakarta.annotation-api.version}</version>
-            </dependency>
+            <!--Temporary managed transitive dependency remove once spring-boot.version >= 3.5.16-->
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-bom</artifactId>
@@ -75,10 +60,16 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!--Temporary managed transitive dependency remove once uk.gov.companieshouse:structured-logging >= 3.0.57-->
+            <dependency>
+                <groupId>io.opentelemetry.semconv</groupId>
+                <artifactId>opentelemetry-semconv</artifactId>
+                <version>1.42.0</version>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring-boot-version}</version>
+                <version>${spring-boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -101,29 +92,19 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>${spring-boot-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-            <version>${spring-boot-version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
-            <version>${spring-boot-version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
-            <version>${spring-boot-version}</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
@@ -148,17 +129,6 @@
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>rest-service-common-library</artifactId>
             <version>${rest-service-common-library.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind.version}</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
@@ -190,12 +160,6 @@
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>kafka-models</artifactId>
             <version>${kafka-models.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
@@ -211,11 +175,6 @@
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
             <version>${avro.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>${jackson-core-version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <kafka-clients.version>4.2.0</kafka-clients.version>
         <rest-service-common-library.version>2.0.14</rest-service-common-library.version>
         <ch-kafka.version>3.0.15</ch-kafka.version>
-        <private-api-sdk-java.version>7.0.4</private-api-sdk-java.version>
+        <private-api-sdk-java.version>6.0.33</private-api-sdk-java.version>
         <jib-maven-plugin.version>3.5.1</jib-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
         <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
@@ -59,6 +59,17 @@
                 <version>${log4j.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!--Temporary managed transitive dependency remove once spring-boot.version >= 3.5.16-->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>10.1.56</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>10.1.56</version>
             </dependency>
             <!--Temporary managed transitive dependency remove once uk.gov.companieshouse:structured-logging >= 3.0.57-->
             <dependency>

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/Application.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/Application.java
@@ -3,7 +3,7 @@ package uk.gov.companieshouse.api.strikeoffobjections;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.util.TimeZone;
 
 @SpringBootApplication

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/config/ValidationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/config/ValidationConfig.java
@@ -10,7 +10,7 @@ import uk.gov.companieshouse.api.strikeoffobjections.validation.AllowedValuesVal
 import uk.gov.companieshouse.api.strikeoffobjections.validation.DisallowedValuesValidationRule;
 import uk.gov.companieshouse.api.strikeoffobjections.validation.ValidationRule;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.util.Arrays;
 import java.util.List;
 

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/authorization/AttachmentDownloadAuthorizationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/interceptor/authorization/AttachmentDownloadAuthorizationInterceptor.java
@@ -12,7 +12,7 @@ import uk.gov.companieshouse.api.strikeoffobjections.service.impl.ERICHeaderFiel
 import uk.gov.companieshouse.api.strikeoffobjections.service.impl.ERICHeaderParser;
 import uk.gov.companieshouse.service.ServiceException;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 public class AttachmentDownloadAuthorizationInterceptor implements HandlerInterceptor {
 

--- a/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
+++ b/src/main/java/uk/gov/companieshouse/api/strikeoffobjections/service/impl/ObjectionService.java
@@ -39,7 +39,7 @@ import uk.gov.companieshouse.service.ServiceException;
 import uk.gov.companieshouse.service.ServiceResult;
 import uk.gov.companieshouse.service.links.Links;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;


### PR DESCRIPTION
This PR bumps a bunch of dependencies to fix critical vulnerabilities.

Also changed to use jakarta instead of javax

The private-api-sdk version 7.0.0 is causing a dependency issue with jackson so have used version 6

Jira ticket: https://companieshouse.atlassian.net/browse/ASM-2628
